### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,6 +16,7 @@
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 brew install python3
 brew install katago
+brew sdl sdl_image sdl_mixer sdl_ttf portmidi
 pip3 install katrain
 ```
 Now you can start KaTrain by simply typing `katrain` in a terminal.


### PR DESCRIPTION
OSX Catalina doesn't have the SDL library available initially and this causes the pygame install to fail.  The following pygame docs include the modified line in their installation instructions:   
`brew sdl sdl_image sdl_mixer sdl_ttf portmidi`  
https://cs.hofstra.edu/docs/pages/guides/InstallingPygame.html#procedure-mac-os-x