### PR TITLE
Mistake button: WCAG compliant color

### DIFF
--- a/katrain/gui.kv
+++ b/katrain/gui.kv
@@ -236,7 +236,7 @@
             on_press: root.katrain('redo',999)
         NavIconButton:
             icon: 'img/Next-Mistake.png'
-            color: [0.65,0.05,0.05,1]
+            color: [0.93,0.07,0.07,1]
             on_press: root.katrain('next-mistake')
     ClickableLabel:
         pos_hint: {'center_x': 0.85,'center_y':0.5}


### PR DESCRIPTION
from
![image](https://user-images.githubusercontent.com/12851952/99965107-a9ac8e80-2d94-11eb-8dd4-e3757d402707.png)
to 
![image](https://user-images.githubusercontent.com/12851952/99965119-b335f680-2d94-11eb-8a02-3f466abe5826.png)

now compliant with the WCAG minimum - pushing the luminosity further would make it too pink.

(ss using https://webaim.org/resources/contrastchecker/ )