### PR TITLE
Add support for "fallback" or "default" encoding for SGFs with no "CA"?

### DIFF
--- a/katrain/core/sgf_parser.py
+++ b/katrain/core/sgf_parser.py
@@ -1,4 +1,5 @@
 import copy
+import chardet
 import math
 import re
 from collections import defaultdict
@@ -345,7 +346,7 @@ class SGFNode:
 
 
 class SGF:
-    DEFAULT_ENCODING = "ISO-8859-1"  # as specified by the standard
+    DEFAULT_ENCODING = "UTF-8"
 
     _NODE_CLASS = SGFNode  # Class used for SGF Nodes, can change this to something that inherits from SGFNode
     # https://xkcd.com/1171/
@@ -385,7 +386,10 @@ class SGF:
                     if match:
                         encoding = match[1].decode("ascii", errors="ignore")
                     else:
-                        encoding = cls.DEFAULT_ENCODING
+                        encoding = chardet.detect(bin_contents[:300])['encoding']
+                        # workaround for some compatibility issues for Windows-1252 and GB2312 encodings
+                        if encoding == "Windows-1252" or encoding == "GB2312":
+                            encoding = "GBK"
             try:
                 decoded = bin_contents.decode(encoding=encoding, errors="ignore")
             except LookupError:

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "urllib3",
         "pygame;platform_system=='Darwin'",  # some mac versions need this for kivy
         "screeninfo;platform_system!='Darwin'",  # for screen resolution, has problems on macos
+        "chardet",  # for automatic encoding detection
     ],
     dependency_links=["https://kivy.org/downloads/simple/"],
     python_requires=">=3.6, <4",


### PR DESCRIPTION
Hi,
This is an intial patch for feature request. As mentioned in the commit, some servers generate SGF files with no "CA" property. (In my case, it's a SGF file with player name in GBK encoding, but has no "CA").

I know it's better to be fixed from server side, but I think it would be nice if we can provide some "fallback" encoding for these sgf files rather than using the default "ISO-8859-1" encoding.

3 solutions I can think of:
1. Use "chardet" etc. lib to detect encoding if no "CA" specified.
2. Add extra "fallback_encoding" parameter as in my patch, and config it in config.json (or even better, UI settings).
3. Or if #2 is too confusing, use the current "encoding" parameter as "fallback encoding".

Not sure which solution is better. But anyway just a suggestion. Or if there is anything I can do to improve the patch, please also let me know.

BTW, Thanks for this awesome software!