### PR TITLE
update JP translations (prune branch, full strength katago)

### DIFF
--- a/katrain/i18n/locales/jp/LC_MESSAGES/katrain.po
+++ b/katrain/i18n/locales/jp/LC_MESSAGES/katrain.po
@@ -482,7 +482,7 @@ msgid "strength:dan"
 msgstr "段"
 
 msgid "ai:default"
-msgstr "KataGo"
+msgstr "手加減なし"
 
 msgid "aihelp:default"
 msgstr ""
@@ -963,7 +963,7 @@ msgstr "全局"
 msgid "ai:antimirror"
 msgstr "Kataマネ碁破り"
 
-#. TODO - on move tree editing, deletes all other branches splitting off from
+#. on move tree editing, deletes all other branches splitting off from
 #. the path UP TO this node
 msgid "Prune Branch"
-msgstr "Prune Branch"
+msgstr "この枝だけ残して他を削除"


### PR DESCRIPTION
I've heard that some users only change "AI settings" (F7) and forget to change "AI Strategy" in "Player Setup". They say "Calibrated Rank is broken" and give up using katrain. So I'd like to rename JP translation of the AI strategy "katago" to something like "no go-easy-on" (= full strength). Is this acceptable?

(BTW, aihelp:antimirror seems missing in *.po.)
