### PR TITLE
[WIP] Native file chooser with plyer.

### DIFF
--- a/katrain/__main__.py
+++ b/katrain/__main__.py
@@ -559,9 +559,10 @@ class KaTrainGui(Screen, KaTrainBase):
             self.game.redo(999)
 
     def _do_analyze_sgf_popup(self):
-        filename = filechooser.open_file(title="Pick an SGF file..", multiple=False, filters=[("Smart Game Format", "*.sgf"), ("All files", "*.*")])[0]
-        print(filename)
-        self.load_sgf_file(filename)
+        pathslist = filechooser.open_file(title=i18n._("load sgf title"), multiple=False, filters=[("Smart Game Format", "*.sgf"), ("All files", "*.*")])
+        if pathslist:
+            filename = pathslist[0]
+            self.load_sgf_file(filename)
 
     def _do_save_game(self, filename=None):
         filename = filename or self.game.sgf_filename

--- a/katrain/__main__.py
+++ b/katrain/__main__.py
@@ -45,6 +45,7 @@ import time
 import random
 import glob
 
+from plyer import filechooser
 from kivy.base import ExceptionHandler, ExceptionManager
 from kivy.app import App
 from kivy.core.clipboard import Clipboard
@@ -558,28 +559,9 @@ class KaTrainGui(Screen, KaTrainBase):
             self.game.redo(999)
 
     def _do_analyze_sgf_popup(self):
-        if not self.fileselect_popup:
-            popup_contents = LoadSGFPopup(self)
-            popup_contents.filesel.path = os.path.abspath(os.path.expanduser(self.config("general/sgf_load", ".")))
-            self.fileselect_popup = I18NPopup(
-                title_key="load sgf title", size=[dp(1200), dp(800)], content=popup_contents
-            ).__self__
-
-            def readfile(*_args):
-                filename = popup_contents.filesel.filename
-                self.fileselect_popup.dismiss()
-                path, file = os.path.split(filename)
-                if path != self.config("general/sgf_load"):
-                    self.log(f"Updating sgf load path default to {path}", OUTPUT_DEBUG)
-                    self._config["general"]["sgf_load"] = path
-                popup_contents.update_config(False)
-                self.save_config("general")
-                self.load_sgf_file(filename, popup_contents.fast.active, popup_contents.rewind.active)
-
-            popup_contents.filesel.on_success = readfile
-            popup_contents.filesel.on_submit = readfile
-        self.fileselect_popup.open()
-        self.fileselect_popup.content.filesel.ids.list_view._trigger_update()
+        filename = filechooser.open_file(title="Pick an SGF file..", multiple=False, filters=[("Smart Game Format", "*.sgf"), ("All files", "*.*")])[0]
+        print(filename)
+        self.load_sgf_file(filename)
 
     def _do_save_game(self, filename=None):
         filename = filename or self.game.sgf_filename

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ Pygments==2.7.4
 requests==2.25.0
 urllib3==1.26.5
 numpy==1.22.3
+plyer==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         "pygame;platform_system=='Darwin'",  # some mac versions need this for kivy
         "screeninfo;platform_system!='Darwin'",  # for screen resolution, has problems on macos
         "chardet",  # for automatic encoding detection
+        "plyer", # for native file chooser.
     ],
     dependency_links=["https://kivy.org/downloads/simple/"],
     python_requires=">=3.7, <3.11",


### PR DESCRIPTION
Hello! I was drawn to Issue #535, @pdeblanc's request for a native file picker, through its https://github.com/sanderland/katrain/labels/good%20first%20issue label. After doing some Googling, I came across Kivy Plyer's platform-independent [filechooser](https://plyer.readthedocs.io/en/latest/#plyer.facades.FileChooser) interface. I introduce its `open_file` function to `_do_analyze_sgf_popup` in this first draft.

Is this the right direction? If not, I'm open to hearing any pointers. If it is, I will work on adding back those two checkboxes "Use fast analysis" and "Rewind to start." Maybe with a Kivy popup that appears only if a file is chosen? (Unfortunately, plyer seems not to support custom checkboxes like this one:)

![custom checkboxes example](https://user-images.githubusercontent.com/116157310/198185258-fc82e4ba-db4b-44dd-a60a-13d438b1313c.png)

One last note: this code no longer tracks `path=self.config("general/sgf_load")`, as native pickers should do that themselves. If I missed anything, please let me know.

✅Tested and works on Windows.
❌Not tested on Linux.
❌Not tested on MacOS.

