### PR TITLE
Escape the distributed contribution command settings

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,7 +29,7 @@ Users with the last generation M1 macs with different architecture should then `
 brew install python3
 brew install katago
 pip3 install katrain
-
+```
 Now you can start KaTrain by simply typing `katrain` in a terminal after adding it to your path.
 
 These commands install [Homebrew](https://brew.sh), which simplifies installing packages,

--- a/katrain/core/contribute_engine.py
+++ b/katrain/core/contribute_engine.py
@@ -72,7 +72,7 @@ class KataGoContributeEngine(BaseEngine):
         self.max_buffer_games = 2 * settings_dict["maxSimultaneousGames"]
         settings = {f"{k}={v}" for k, v in settings_dict.items()}
         self.command = shlex.split(
-            f'"{exe}" contribute -config "{cfg}" -base-dir "{base_dir}" -override-config "{",".join(settings)}"'
+            f'"{exe}" contribute -config "{cfg}" -base-dir "{base_dir}" -override-config {shlex.quote(",".join(settings))}'
         )
         self.start()
 


### PR DESCRIPTION
Fields passed to the distributed contribution command were unescaped, which caused some parameters (such as passwords) to close the command quote early.