### PR TITLE
fix: restrict the range of index when moving through variations

### DIFF
--- a/katrain/gui/badukpan.py
+++ b/katrain/gui/badukpan.py
@@ -1136,7 +1136,7 @@ class BadukPanWidget(Widget):
             if self.animating_pv:
                 pv, node, start_time, _ = self.animating_pv
                 delay = self.katrain.config("general/anim_pv_time", 0.5)
-                return (time.time() - start_time) / max(delay, 0.1)
+                return min(len(pv), (time.time() - start_time) / max(delay, 0.1))
             else:
                 return 0
 


### PR DESCRIPTION
When move through the node variations ,  restrict the index goes too far from the end.