### PR TITLE
Upgrades from 1.14.0 to KivyMD 1.1.1

### DIFF
--- a/katrain/KataGo/analysis_config.cfg
+++ b/katrain/KataGo/analysis_config.cfg
@@ -94,6 +94,7 @@ nnMaxBatchSize = 96
 # This is the number of CPU threads for evaluating the neural net on the Eigen backend.
 # It defaults to min(numAnalysisThreads * numSearchThreadsPerAnalysisThread, numCPUCores).
 # numEigenThreadsPerModel = X
+numAnalysisThreads = 12
 
 # Uncomment and set these smaller if you ONLY are going to use the analysis engine for smaller boards (or plan to
 # run multiple instances, with some instances only handling smaller boards). It should improve performance.

--- a/katrain/core/contribute_engine.py
+++ b/katrain/core/contribute_engine.py
@@ -72,7 +72,7 @@ class KataGoContributeEngine(BaseEngine):
         self.max_buffer_games = 2 * settings_dict["maxSimultaneousGames"]
         settings = {f"{k}={v}" for k, v in settings_dict.items()}
         self.command = shlex.split(
-            f'"{exe}" contribute -config "{cfg}" -base-dir "{base_dir}" -override-config "{",".join(settings)}"'
+            f'"{exe}" contribute -config "{cfg}" -base-dir "{base_dir}" -override-config {shlex.quote(",".join(settings))}'
         )
         self.start()
 

--- a/katrain/core/engine.py
+++ b/katrain/core/engine.py
@@ -128,7 +128,7 @@ class KataGoEngine(BaseEngine):
                 self.on_error(i18n._("Kata config not found").format(config=cfg), code="KATAGO-FILES")
                 return  # don't start
             self.command = shlex.split(
-                f'"{exe}" analysis -model "{model}" -config "{cfg}" -analysis-threads {config["threads"]} -override-config "homeDataDir={os.path.expanduser(DATA_FOLDER)}"'
+                f'"{exe}" analysis -model "{model}" -config "{cfg}" -override-config "homeDataDir={os.path.expanduser(DATA_FOLDER)}"'
             )
         self.start()
 

--- a/katrain/gui.kv
+++ b/katrain/gui.kv
@@ -108,7 +108,7 @@
         font_name: root.font_name
         font_size: 0.6 * self.height / len(self.text.split('\\n')) if root._font_size is None else root._font_size
         halign: root.halign
-        text: root.text
+        text: root.text_katrain
 
 <AutoSizedButton>:
     width: root.label.texture_size[0]
@@ -743,7 +743,7 @@
         halign: 'center'
         font_size: root.height / 3
         font_name: root.font_name
-        color: checkbox.disabled_color if root.disabled else (checkbox.selected_color if checkbox.active else checkbox.unselected_color)
+        color: checkbox.disabled_color if root.disabled else (checkbox.selected_color if checkbox.active else checkbox.unselected_color) or [1,1,1]
         size_hint_x: None
         width: self.texture_size[0] + 4
         on_left_press: checkbox.trigger_action()
@@ -1142,7 +1142,7 @@
     analysis_controls: analysis_controls
     nav_drawer: nav_drawer
     nav_drawer_contents: nav_drawer_contents
-    NavigationLayout:
+    MDNavigationLayout:
         ScreenManager:
             Screen:
                 name: 'gui'

--- a/katrain/gui/kivyutils.py
+++ b/katrain/gui/kivyutils.py
@@ -23,7 +23,7 @@ from kivy.uix.widget import Widget
 from kivymd.app import MDApp
 from kivymd.uix.behaviors import CircularRippleBehavior, RectangularRippleBehavior
 from kivymd.uix.boxlayout import MDBoxLayout
-from kivymd.uix.button import BaseFlatButton, BasePressedButton
+from kivymd.uix.button import MDFlatButton
 from kivymd.uix.navigationdrawer import MDNavigationDrawer
 from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.textfield import MDTextField
@@ -107,8 +107,8 @@ class LeftButtonBehavior(ButtonBehavior):  # stops buttons etc activating on rig
 
 
 # -- resizeable buttons / avoid baserectangular for sizing
-class SizedButton(LeftButtonBehavior, RectangularRippleBehavior, BasePressedButton, BaseFlatButton, BackgroundMixin):
-    text = StringProperty("")
+class SizedButton(LeftButtonBehavior, MDFlatButton, BackgroundMixin):
+    text_katrain = StringProperty("")
     text_color = ListProperty(Theme.BUTTON_TEXT_COLOR)
     text_size = ListProperty([100, 100])
     halign = OptionProperty("center", options=["left", "center", "right", "justify", "auto"])

--- a/katrain/gui/sound.py
+++ b/katrain/gui/sound.py
@@ -23,7 +23,7 @@ def play_sound(file, volume=1, cache=True):
     if app and app.gui and app.gui.config("timer/sound"):
         sound = cached_sounds.get(file)
         if sound is None:
-            sound = SoundLoader.load(file)
+            #sound = SoundLoader.load(file) #NO SOUNDS WITH KIVY 1.1.1
             if cache:
                 cached_sounds[file] = sound
         if sound is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ chardet==3.0.4
 docutils==0.16
 ffpyplayer==4.3.2
 idna==2.10
-Kivy==2.1.0
+kivy[full]==2.2.1
 Kivy-Garden==0.1.4
-kivymd==0.104.1
+kivymd==1.1.1
 Pillow==9.3.0
 Pygments==2.7.4
 requests==2.31.0


### PR DESCRIPTION
It's a bit of a dirty PR with only one commit. I cherry-picked a few commits from the 1.15.0 branch, and then did some work to update the button and MDNavigationLayout to work with KivyMD 1.1.1.

Adding these commits on top of 1.14.0 will make katrain run without sounds on Manjaro Linux as of 22.5.2024.

There's another PR for KivyMD 2.0.0 here, but I ran into things that are likely bugs with KivyMD git version, so it's probably better to wait until 2.0.0 is ready for release and not mess around with the development version.
https://github.com/sanderland/katrain/pull/684