### PR TITLE
Align values in the stat box

### DIFF
--- a/katrain/gui.kv
+++ b/katrain/gui.kv
@@ -457,7 +457,6 @@
 
 
 <StatsLabel>:
-    orientation: 'horizontal'
     size_hint_y: EPSILON if root.hidden else 1
     opacity: 0 if root.hidden else 1
     Label:
@@ -470,37 +469,53 @@
         halign: 'center'
         text: root.label
         max_lines: 1
+
+<StatsValue>:
+    size_hint_y: EPSILON if root.hidden else 1
+    opacity: 0 if root.hidden else 1
     Label:
         size_hint: 0.4,1
         color: root.color
-        font_size: desc.font_size
+        font_size: self.height * 0.7
         font_name: root.font_name
         text_size: self.size
         valign: 'middle'
-        halign: 'center'
+        halign: 'left'
         bold: True
         text: root.text
         max_lines: 1
 
 <StatsBox>
-    orientation: 'vertical'
+    cols: 2
     background_color: Theme.BOX_BACKGROUND_COLOR
     labels: {'score':score_label,'winrate':winrate_label,'points':pointloss_label}
     StatsLabel:
         id: winrate_label
         label: i18n._('stats:winrate')
-        text: root.winrate
         color: Theme.WINRATE_COLOR
+    StatsValue:
+        id: winrate_value
+        hidden: winrate_label.hidden
+        color: winrate_label.color
+        text: root.winrate
     StatsLabel:
         id: score_label
         label: i18n._('stats:score')
-        text: root.score
         color: Theme.SCORE_COLOR
+    StatsValue:
+        id: score_value
+        hidden: score_label.hidden
+        color: score_label.color
+        text: root.score
     StatsLabel:
         id: pointloss_label
         label: i18n._('stats:pointslost') if root.points_lost is None or root.points_lost > 0 else i18n._('stats:pointsgained')
-        text: '{}: {:.1f}'.format(i18n._(f'short color {root.player}'), abs(root.points_lost)) if root.points_lost is not None else '...'
         color: Theme.POINTLOSS_COLOR
+    StatsValue:
+        id: pointloss_value
+        hidden: pointloss_label.hidden
+        color: pointloss_label.color
+        text: '{}: {:.1f}'.format(i18n._(f'short color {root.player}'), abs(root.points_lost)) if root.points_lost is not None else '...'
 
 <ScrollableLabel>:
     background_color: Theme.BOX_BACKGROUND_COLOR

--- a/katrain/gui.kv
+++ b/katrain/gui.kv
@@ -455,66 +455,60 @@
     text: '+0'
     size: self.texture_size
 
-
 <StatsLabel>:
     size_hint_y: EPSILON if root.hidden else 1
     opacity: 0 if root.hidden else 1
-    Label:
-        size_hint: 0.6,1
-        id: desc
-        font_size: self.height * 0.7
-        font_name: root.font_name
-        text_size: self.size
-        valign: 'middle'
-        halign: 'center'
-        text: root.label
-        max_lines: 1
+    size_hint: 0.6,1
+    font_size: self.height * 0.7
+    font_name: root.font_name
+    text_size: self.size
+    valign: 'middle'
+    halign: 'left'
+    text: root.label
+    max_lines: 1
 
 <StatsValue>:
     size_hint_y: EPSILON if root.hidden else 1
     opacity: 0 if root.hidden else 1
-    Label:
-        size_hint: 0.4,1
-        color: root.color
-        font_size: self.height * 0.7
-        font_name: root.font_name
-        text_size: self.size
-        valign: 'middle'
-        halign: 'left'
-        bold: True
-        text: root.text
-        max_lines: 1
+    size_hint: 0.4,1
+    color: root.color
+    font_size: self.height * 0.7
+    font_name: root.font_name
+    text_size: self.size
+    valign: 'middle'
+    halign: 'left'
+    bold: True
+    text: root.text
+    max_lines: 1
 
 <StatsBox>
     cols: 2
     background_color: Theme.BOX_BACKGROUND_COLOR
     labels: {'score':score_label,'winrate':winrate_label,'points':pointloss_label}
+    padding: CP_PADDING
     StatsLabel:
         id: winrate_label
         label: i18n._('stats:winrate')
-        color: Theme.WINRATE_COLOR
     StatsValue:
         id: winrate_value
         hidden: winrate_label.hidden
-        color: winrate_label.color
+        color: Theme.WINRATE_COLOR
         text: root.winrate
     StatsLabel:
         id: score_label
         label: i18n._('stats:score')
-        color: Theme.SCORE_COLOR
     StatsValue:
         id: score_value
         hidden: score_label.hidden
-        color: score_label.color
+        color: Theme.SCORE_COLOR
         text: root.score
     StatsLabel:
         id: pointloss_label
         label: i18n._('stats:pointslost') if root.points_lost is None or root.points_lost > 0 else i18n._('stats:pointsgained')
-        color: Theme.POINTLOSS_COLOR
     StatsValue:
         id: pointloss_value
         hidden: pointloss_label.hidden
-        color: pointloss_label.color
+        color: Theme.POINTLOSS_COLOR
         text: '{}: {:.1f}'.format(i18n._(f'short color {root.player}'), abs(root.points_lost)) if root.points_lost is not None else '...'
 
 <ScrollableLabel>:

--- a/katrain/gui.kv
+++ b/katrain/gui.kv
@@ -455,31 +455,26 @@
     text: '+0'
     size: self.texture_size
 
-<StatsLabel>:
+<StatsItem>:
     size_hint_y: EPSILON if root.hidden else 1
     opacity: 0 if root.hidden else 1
-    size_hint: 0.6,1
     font_size: self.height * 0.7
     font_name: root.font_name
     text_size: self.size
     valign: 'middle'
-    halign: 'left'
-    text: root.label
     max_lines: 1
 
+<StatsLabel>:
+    size_hint: 0.6,1
+    halign: 'left'
+    text: root.label
+
 <StatsValue>:
-    size_hint_y: EPSILON if root.hidden else 1
-    opacity: 0 if root.hidden else 1
     size_hint: 0.4,1
     color: root.color
-    font_size: self.height * 0.7
-    font_name: root.font_name
-    text_size: self.size
-    valign: 'middle'
     halign: 'left'
     bold: True
-    text: root.text
-    max_lines: 1
+    text: root.value
 
 <StatsBox>
     cols: 2
@@ -493,7 +488,7 @@
         id: winrate_value
         hidden: winrate_label.hidden
         color: Theme.WINRATE_COLOR
-        text: root.winrate
+        value: root.winrate
     StatsLabel:
         id: score_label
         label: i18n._('stats:score')
@@ -501,7 +496,7 @@
         id: score_value
         hidden: score_label.hidden
         color: Theme.SCORE_COLOR
-        text: root.score
+        value: root.score
     StatsLabel:
         id: pointloss_label
         label: i18n._('stats:pointslost') if root.points_lost is None or root.points_lost > 0 else i18n._('stats:pointsgained')
@@ -509,7 +504,7 @@
         id: pointloss_value
         hidden: pointloss_label.hidden
         color: Theme.POINTLOSS_COLOR
-        text: '{}: {:.1f}'.format(i18n._(f'short color {root.player}'), abs(root.points_lost)) if root.points_lost is not None else '...'
+        value: '{}: {:.1f}'.format(i18n._(f'short color {root.player}'), abs(root.points_lost)) if root.points_lost is not None else '...'
 
 <ScrollableLabel>:
     background_color: Theme.BOX_BACKGROUND_COLOR

--- a/katrain/gui/kivyutils.py
+++ b/katrain/gui/kivyutils.py
@@ -178,13 +178,13 @@ class LightLabel(Label):
     pass
 
 
-class StatsLabel(MDBoxLayout):
+class StatsLabel(Label):
     label = StringProperty("")
     color = ListProperty([1, 1, 1, 1])
     hidden = BooleanProperty(False)
     font_name = StringProperty(Theme.DEFAULT_FONT)
 
-class StatsValue(MDBoxLayout):
+class StatsValue(Label):
     text = StringProperty("")
     color = ListProperty([1, 1, 1, 1])
     hidden = BooleanProperty(False)

--- a/katrain/gui/kivyutils.py
+++ b/katrain/gui/kivyutils.py
@@ -178,17 +178,18 @@ class LightLabel(Label):
     pass
 
 
-class StatsLabel(Label):
-    label = StringProperty("")
-    color = ListProperty([1, 1, 1, 1])
+class StatsItem(Label):
     hidden = BooleanProperty(False)
     font_name = StringProperty(Theme.DEFAULT_FONT)
 
-class StatsValue(Label):
-    text = StringProperty("")
+
+class StatsLabel(StatsItem):
+    label = StringProperty("")
+
+
+class StatsValue(StatsItem):
+    value = StringProperty("")
     color = ListProperty([1, 1, 1, 1])
-    hidden = BooleanProperty(False)
-    font_name = StringProperty(Theme.DEFAULT_FONT)
 
 
 class MyNavigationDrawer(MDNavigationDrawer):

--- a/katrain/gui/kivyutils.py
+++ b/katrain/gui/kivyutils.py
@@ -23,9 +23,9 @@ from kivy.uix.widget import Widget
 from kivymd.app import MDApp
 from kivymd.uix.behaviors import CircularRippleBehavior, RectangularRippleBehavior
 from kivymd.uix.boxlayout import MDBoxLayout
+from kivymd.uix.gridlayout import MDGridLayout
 from kivymd.uix.button import BaseFlatButton, BasePressedButton
 from kivymd.uix.navigationdrawer import MDNavigationDrawer
-from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.textfield import MDTextField
 
 from katrain.core.constants import (
@@ -179,8 +179,13 @@ class LightLabel(Label):
 
 
 class StatsLabel(MDBoxLayout):
-    text = StringProperty("")
     label = StringProperty("")
+    color = ListProperty([1, 1, 1, 1])
+    hidden = BooleanProperty(False)
+    font_name = StringProperty(Theme.DEFAULT_FONT)
+
+class StatsValue(MDBoxLayout):
+    text = StringProperty("")
     color = ListProperty([1, 1, 1, 1])
     hidden = BooleanProperty(False)
     font_name = StringProperty(Theme.DEFAULT_FONT)
@@ -629,7 +634,7 @@ class CollapsablePanel(MDBoxLayout):
         pass
 
 
-class StatsBox(MDBoxLayout, BackgroundMixin):
+class StatsBox(MDGridLayout, BackgroundMixin):
     winrate = StringProperty("...")
     score = StringProperty("...")
     points_lost = NumericProperty(None, allownone=True)


### PR DESCRIPTION
This is a subjective design improvement. The dimensions for left and right are unchanged, so all languages still fit. If there is yet another localization that has a longer description, it'd be simple to make the grid responsive.

Before:
<img width="424" alt="image" src="https://github.com/user-attachments/assets/10549adc-af37-46f9-a0b2-d8c9b56781ef">

After:
<img width="431" alt="image" src="https://github.com/user-attachments/assets/3ad50d27-2e1e-47fe-974a-91343fd591c0">

