### PR TITLE
add option to generate game with random advantage

### DIFF
--- a/katrain/__main__.py
+++ b/katrain/__main__.py
@@ -450,6 +450,19 @@ class KaTrainGui(Screen, KaTrainBase):
     def _do_selfplay_setup(self, until_move, target_b_advantage=None):
         self.game.selfplay(int(until_move) if isinstance(until_move, float) else until_move, target_b_advantage)
 
+    def _do_regenerate_game(self):
+        self._do_new_game()
+        use_random_advantage = self.config(f"game/use_random_advantage")
+        if use_random_advantage:
+            advantage_options = self.config("game/random_advantage_options")
+            advantage_values = [float(x.strip()) for x in advantage_options.split(",")]
+            target_advantage = random.choice(advantage_values)
+            self.log(f"Using random advantage from options: {target_advantage}", OUTPUT_INFO)
+        else:
+            target_advantage = self.config("game/setup_advantage")
+        num_moves = int(self.config("game/setup_move"))
+        self.game.selfplay(num_moves, target_advantage)
+
     def _do_select_box(self):
         self.controls.set_status(i18n._("analysis:region:start"), STATUS_INFO)
         self.board_gui.selecting_region_of_interest = True
@@ -688,6 +701,7 @@ class KaTrainGui(Screen, KaTrainBase):
                 (Theme.KEY_INSERT_MODE, ("insert-mode",)),
                 (Theme.KEY_PASS, ("play", None)),
                 (Theme.KEY_SELFPLAY_TO_END, ("selfplay-setup", "end", None)),
+                (Theme.KEY_REGENERATE_GAME, ("regenerate-game",)),
                 (Theme.KEY_NAV_PREV_BRANCH, ("undo", "branch")),
                 (Theme.KEY_NAV_BRANCH_DOWN, ("switch-branch", 1)),
                 (Theme.KEY_NAV_BRANCH_UP, ("switch-branch", -1)),

--- a/katrain/gui/popups.py
+++ b/katrain/gui/popups.py
@@ -269,6 +269,8 @@ class ConfigTimerPopup(QuickConfigGui):
 
 class NewGamePopup(QuickConfigGui):
     mode = StringProperty("newgame")
+    random_advantage = BooleanProperty(False)
+    advantage_options = StringProperty("-15,0,15")  # default values
 
     def __init__(self, katrain):
         super().__init__(katrain)
@@ -335,7 +337,21 @@ class NewGamePopup(QuickConfigGui):
                 self.katrain.game.analyze_all_nodes(analyze_fast=True)
         else:  # setup position
             self.katrain._do_new_game()
-            self.katrain("selfplay-setup", props["game/setup_move"], props["game/setup_advantage"])
+            if self.random_advantage:
+                try:
+                    advantage_values = [float(x.strip()) for x in self.advantage_options.split(",")]
+                    if not advantage_values:
+                        raise ValueError("No values provided")
+                    import random
+
+                    target_advantage = random.choice(advantage_values)
+                    self.katrain.log(f"Using random advantage from options: {target_advantage}", OUTPUT_INFO)
+                    self.katrain("selfplay-setup", props["game/setup_move"], target_advantage)
+                except Exception as e:
+                    self.katrain.log(f"Error parsing advantage options: {e}", OUTPUT_ERROR)
+                    self.katrain("selfplay-setup", props["game/setup_move"], props["game/setup_advantage"])
+            else:
+                self.katrain("selfplay-setup", props["game/setup_move"], props["game/setup_advantage"])
         self.update_playerinfo()  # name
 
 
@@ -488,7 +504,7 @@ class BaseConfigPopup(QuickConfigGui):
         "linux": {
             "OpenCL v1.15.3": "https://github.com/lightvector/KataGo/releases/download/v1.15.3/katago-v1.15.3-opencl-linux-x64.zip",
             "Eigen AVX2 (Modern CPUs) v1.15.3": "https://github.com/lightvector/KataGo/releases/download/v1.15.3/katago-v1.15.3-eigenavx2-linux-x64.zip",
-            "Eigen (CPU, Non-optimized) v1.15.3": "https://github.com/lightvector/KataGo/releases/download/v1.15.3/katago-v1.15.3-eigen-linux-x64.zip",            
+            "Eigen (CPU, Non-optimized) v1.15.3": "https://github.com/lightvector/KataGo/releases/download/v1.15.3/katago-v1.15.3-eigen-linux-x64.zip",
             "OpenCL v1.15.3 (bigger boards)": "https://github.com/lightvector/KataGo/releases/download/v1.15.3/katago-v1.15.3-opencl-linux-x64+bs29.zip",
         },
         "just-descriptions": {},

--- a/katrain/gui/theme.py
+++ b/katrain/gui/theme.py
@@ -198,6 +198,7 @@ class Theme:
     KEY_RESET_ANALYSIS = "h"
     KEY_INSERT_MODE = "i"
     KEY_SELFPLAY_TO_END = "l"
+    KEY_REGENERATE_GAME = ";"
     KEY_STOP_ANALYSIS = "escape"
     KEY_TOGGLE_CONTINUOUS_ANALYSIS = "spacebar"
     KEY_TOGGLE_MOVENUM = "m"

--- a/katrain/popups.kv
+++ b/katrain/popups.kv
@@ -717,18 +717,48 @@
         orientation: 'vertical'
         SmallDescriptionLabel:
             text: i18n._('setup position explanation')
-            size_hint: 1, 1.5
+            size_hint: 1, 1.0
         GridLayout:
             cols: 2
-            rows: 2
-            size_hint: 1,2
+            rows: 4
+            spacing: [10, 15]  # Add spacing between elements
+            padding: [5, 10]   # Add padding around grid
+            size_hint: 1, 2.5  # Increase height to accommodate spacing
+            
+            # Random Advantage Checkbox
+            DescriptionLabel:
+                text: i18n._('Random Advantage')
+            AnchorLayout:
+                LabelledCheckBox:
+                    input_property: 'game/use_random_advantage'
+                    active: root.random_advantage
+                    on_active: root.random_advantage = self.active
+            
+            # Advantage Options
+            DescriptionLabel:
+                text: i18n._('Advantage Options')
+                opacity: 1 if root.random_advantage else 0.5
+            AnchorLayout:
+                LabelledTextInput:
+                    input_property: 'game/random_advantage_options'
+                    text: root.advantage_options
+                    on_text: root.advantage_options = self.text
+                    disabled: not root.random_advantage
+                    opacity: 1 if root.random_advantage else 0.5
+            
+            # Target Score for Black
             DescriptionLabel:
                 text: i18n._('setup position black score')
+                opacity: 1 if not root.random_advantage else 0.5
             AnchorLayout:
                 LabelledSelectionSlider:
                     input_property: 'game/setup_advantage'
                     key_option: True
                     values: [(pt,f"{pt}") for pt in range(-150,151)]
+                    disabled: root.random_advantage
+                    opacity: 1 if not root.random_advantage else 0.5
+            
+            # Move Number
             DescriptionLabel:
                 text: i18n._('setup position move number')
             AnchorLayout:


### PR DESCRIPTION
I find it useful to study board evaluation by looking at a random middle game board and guessing who's ahead and by how much. You can do this now with setup game by choosing a random advantage (and hiding the scoreboard UI so it doesn't tell you the answer). There's a keyboard shortcut ; to do this repeatedly.

I couldn't get the UI to look very nicely though, would appreciate some help on that.
<img width="732" alt="Screenshot 2025-03-14 at 11 47 34 AM" src="https://github.com/user-attachments/assets/9ec30110-ea11-46a9-91a4-25a86abd6e72" />
