### PR TITLE
add point loss graph option

### DIFF
--- a/katrain/gui.kv
+++ b/katrain/gui.kv
@@ -610,12 +610,12 @@
         content_height: graph.height
         options_height: root.tab_option_height
         closed_label: 'closedlabel:scoregraph'
-        options: ['score','winrate']
-        option_colors: [Theme.SCORE_COLOR,Theme.WINRATE_COLOR]
+        options: ['score','winrate','points']
+        option_colors: [Theme.SCORE_COLOR,Theme.WINRATE_COLOR,Theme.POINTLOSS_COLOR]
         option_active: [True,False,False]
         on_option_state:
             graph.show_graphs(args[1])
-            graph.hidden = not (args[1]['score'] or args[1]['winrate'])
+            graph.hidden = not (args[1]['score'] or args[1]['winrate'] or args[1]['points'])
         ScoreGraph:
             id: graph
             opacity: 0 if self.hidden else 1

--- a/katrain/gui/theme.py
+++ b/katrain/gui/theme.py
@@ -154,6 +154,7 @@ class Theme:
     GRAPH_DOT_COLOR = [0.85, 0.3, 0.3, 1]
     WINRATE_MARKER_COLOR = [0.05, 0.7, 0.05, 1]
     SCORE_MARKER_COLOR = [0.2, 0.6, 0.8, 1]
+    POINTLOSS_MARKER_COLOR = [0.7, 0.7, 0.05, 1]
 
     # move tree
     MOVE_TREE_LINE = LIGHT_GREY


### PR DESCRIPTION
Adds a "Point Loss" toggle to the score graph that displays point losses for each move as a line chart. Shows 0 at the bottom and scales to the maximum loss at the top.

Closes #799 

<img width="350" height="287" alt="Screenshot 2026-01-19 at 22 04 23" src="https://github.com/user-attachments/assets/555dd480-3e6f-4d43-b17a-1ebc5c38b664" />
