### PR TITLE
Add macOS Intel (x86_64) build to CI workflow

### DIFF
--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -105,7 +105,15 @@ jobs:
 
   build-macos:
     needs: [prepare, test]
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-latest
+            arch: arm64
+          - runner: macos-15-intel
+            arch: x86_64
+    runs-on: ${{ matrix.runner }}
     env:
       KATRAIN_VERSION: ${{ needs.prepare.outputs.version }}
     steps:
@@ -152,14 +160,14 @@ jobs:
                        -srcfolder dmg_temp \
                        -ov \
                        -format UDZO \
-                       "KaTrain-${{ env.KATRAIN_VERSION }}.dmg"
+                       "KaTrain-${{ env.KATRAIN_VERSION }}-${{ matrix.arch }}.dmg"
         mkdir -p osx_app
-        mv "KaTrain-${{ env.KATRAIN_VERSION }}.dmg" osx_app/
+        mv "KaTrain-${{ env.KATRAIN_VERSION }}-${{ matrix.arch }}.dmg" osx_app/
 
     - name: Upload macOS artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: KaTrainMacOS-${{ env.KATRAIN_VERSION }}
+        name: KaTrainMacOS-${{ env.KATRAIN_VERSION }}-${{ matrix.arch }}
         path: osx_app
 
   # This job publishes the package to PyPI.
@@ -212,7 +220,8 @@ jobs:
           
           ### Downloads
           - **Windows**: Download the `.exe` files or `.zip` folders.
-          - **macOS**: Download the `.dmg` file.
+          - **macOS (Apple Silicon)**: Download the `arm64` `.dmg` file.
+          - **macOS (Intel)**: Download the `x86_64` `.dmg` file.
         files: ./artifacts/*
         draft: true
         prerelease: false


### PR DESCRIPTION
Use a matrix strategy on the build-macos job to produce DMG files for both Apple Silicon (arm64) and Intel (x86_64) architectures, using the macos-latest and macos-15-intel GitHub Actions runners.

Closes #767 