### PR TITLE
Fix deadlock when playing sounds with no audio device available

### DIFF
--- a/katrain/__main__.py
+++ b/katrain/__main__.py
@@ -29,6 +29,11 @@ else:
 Config.set("kivy", "window_icon", ICON)
 Config.set("input", "mouse", "mouse,multitouch_on_demand")
 
+# Preload sounds before Window import creates the SDL2 window,
+# as SoundLoader.load() deadlocks once the SDL2 window exists.
+from katrain.gui.sound import preload_sounds
+preload_sounds(PATHS["PACKAGE"] + "/sounds")
+
 # next, certificates on package builds https://github.com/sanderland/katrain/issues/414
 if getattr(sys, "frozen", False):
     import ssl

--- a/katrain/gui/sound.py
+++ b/katrain/gui/sound.py
@@ -24,31 +24,27 @@ def preload_sounds(sound_dir):
     import sys
     import subprocess
 
-    test_file = None
-    for fname in os.listdir(sound_dir):
-        if fname.endswith((".wav", ".ogg", ".mp3")):
-            test_file = os.path.join(sound_dir, fname)
-            break
-
-    if not test_file:
+    audio_files = [
+        os.path.join(sound_dir, fn) for fn in os.listdir(sound_dir)
+        if fn.endswith((".wav", ".ogg", ".mp3"))
+    ]
+    if not audio_files:
         return
 
     # Test if audio subsystem works by loading one sound in a subprocess
     try:
         subprocess.run(
             [sys.executable, "-c",
-             f"from kivy.core.audio import SoundLoader; SoundLoader.load({test_file!r})"],
+             f"from kivy.core.audio import SoundLoader; SoundLoader.load({audio_files[0]!r})"],
             timeout=3, capture_output=True,
         )
-    except (subprocess.TimeoutExpired, Exception) as e:
+    except subprocess.TimeoutExpired as e:
         print(f"Warning: Audio unavailable ({e}). Sounds disabled.", file=sys.stderr)
         return
 
     # Audio works, preload all sounds
-    for fname in os.listdir(sound_dir):
-        if fname.endswith((".wav", ".ogg", ".mp3")):
-            path = os.path.join(sound_dir, fname)
-            cached_sounds[fname] = SoundLoader.load(path)
+    for path in audio_files:
+        cached_sounds[os.path.basename(path)] = SoundLoader.load(path)
     _audio_available = True
 
 

--- a/katrain/gui/sound.py
+++ b/katrain/gui/sound.py
@@ -53,7 +53,7 @@ def play_sound(file, volume=1, cache=True):
         return
 
     # the following import causes the creation of an SDL2 window, and if there
-    # is no sound device, it deadlocks. We delay the import untile we know audio
+    # is no sound device, it deadlocks. We delay the import until we know audio
     # is available
     from kivymd.app import MDApp
     app = MDApp.get_running_app()

--- a/katrain/gui/sound.py
+++ b/katrain/gui/sound.py
@@ -52,6 +52,9 @@ def play_sound(file, volume=1, cache=True):
     if not _audio_available:
         return
 
+    # the following import causes the creation of an SDL2 window, and if there
+    # is no sound device, it deadlocks. We delay the import untile we know audio
+    # is available
     from kivymd.app import MDApp
     app = MDApp.get_running_app()
     if app and app.gui and app.gui.config("timer/sound"):

--- a/katrain/gui/sound.py
+++ b/katrain/gui/sound.py
@@ -1,9 +1,9 @@
 from kivy.clock import Clock
-from kivymd.app import MDApp
 from kivy.core.audio import SoundLoader
 from kivy.utils import platform
 
 cached_sounds = {}
+_audio_available = False
 
 # prefer ffpyplayer on linux, then others, avoid gst and avoid or ffpyplayer on windows
 ranking = [("ffplay", 98 if platform in ["win", "macosx"] else -2), ("sdl", -1), ("gst", 99), ("", 0)]
@@ -13,22 +13,57 @@ except Exception as e:
     print("Exception sorting sound loaders: ", e)  # private vars, so could break with versions etc
 
 
-def play_sound(file, volume=1, cache=True):
-    def _play(sound):
-        if sound:
-            sound.play()
-            sound.seek(0)
+def preload_sounds(sound_dir):
+    """Preload all sounds before the SDL2 window is created.
 
+    SoundLoader.load() deadlocks when no audio output device is available,
+    so we test audio in a subprocess first.
+    """
+    global _audio_available
+    import os
+    import sys
+    import subprocess
+
+    test_file = None
+    for fname in os.listdir(sound_dir):
+        if fname.endswith((".wav", ".ogg", ".mp3")):
+            test_file = os.path.join(sound_dir, fname)
+            break
+
+    if not test_file:
+        return
+
+    # Test if audio subsystem works by loading one sound in a subprocess
+    try:
+        subprocess.run(
+            [sys.executable, "-c",
+             f"from kivy.core.audio import SoundLoader; SoundLoader.load({test_file!r})"],
+            timeout=3, capture_output=True,
+        )
+    except (subprocess.TimeoutExpired, Exception) as e:
+        print(f"Warning: Audio unavailable ({e}). Sounds disabled.", file=sys.stderr)
+        return
+
+    # Audio works, preload all sounds
+    for fname in os.listdir(sound_dir):
+        if fname.endswith((".wav", ".ogg", ".mp3")):
+            path = os.path.join(sound_dir, fname)
+            cached_sounds[fname] = SoundLoader.load(path)
+    _audio_available = True
+
+
+def play_sound(file, volume=1, cache=True):
+    if not _audio_available:
+        return
+
+    from kivymd.app import MDApp
     app = MDApp.get_running_app()
     if app and app.gui and app.gui.config("timer/sound"):
         sound = cached_sounds.get(file)
-        if sound is None:
-            sound = SoundLoader.load(file)
-            if cache:
-                cached_sounds[file] = sound
         if sound is not None:
             sound.volume = volume
-            Clock.schedule_once(lambda _dt: _play(sound), 0)
+            sound.play()
+            sound.seek(0)
 
 
 def stop_sound(file):


### PR DESCRIPTION
I just had an issue, and fixing it led to these changes. I recognize that I have not checked if you are working in something related to this, because I just wanted to fix my issue, so feel free to do whatever you want with this PR :) I figured it was better to let you know.

I can't say exactly all the steps that led to the issue (working on WSL2 on Windows 11, no speakers, first it worked, then I started using bluetooth earphones, then got the issue when the earphones were not connected).

## Summary

- `SoundLoader.load()` deadlocks when called after the SDL2 window is created and no audio output device is available (e.g., no speakers connected, bluetooth headphones not paired). This causes the entire UI to freeze permanently when placing a stone.
- Fix by preloading all sound files at startup before the SDL2 window exists, and testing audio availability in a subprocess first. If the subprocess times out (no audio device), sounds are gracefully disabled.
- Move the `kivymd.app.MDApp` import from module-level to inside `play_sound()`, since importing `MDApp` triggers SDL2 window creation and would cause the preload to deadlock.

## Details

Two issues combined to cause this issue:

1. **`SoundLoader.load()` hangs** when the SDL2 window is active and no audio output device is available. This is a kivy/ffpyplayer issue where the audio initialization blocks indefinitely.

2. **`sound.py` imported `MDApp` at module level**, which creates the SDL2 window as a side effect. This meant there was no safe point to call `SoundLoader.load()` after importing `sound.py`.

The fix preloads all sounds in `__main__.py` before the `Window` import (line 29), using a new `preload_sounds()` function that:
- Spawns a subprocess to test if `SoundLoader.load()` completes within 3 seconds
- If the test fails (no audio device), skips loading and disables sounds for the session
- If the test passes, preloads all `.wav`/`.ogg`/`.mp3` files from the sounds directory
- `play_sound()` never calls `SoundLoader.load()` during gameplay, only plays from the pre-cached sounds

## How to test

- [x] Launch with no audio device connected — app starts normally, no sound, no freeze
- [x] Launch with audio device connected — app starts normally, stone sounds play
- [x] Place multiple stones in both scenarios — no freezes
- [x] Toggle sound setting off in timer settings — sounds stop
- [x] Toggle sound setting on in timer settings — sounds resume (if audio device available at startup)
