### PR TITLE
Don't discard analysis data when KataGo response includes a "warning" field

### DIFF
--- a/katrain/core/engine.py
+++ b/katrain/core/engine.py
@@ -300,14 +300,17 @@ class KataGoEngine(BaseEngine):
                         )
                     continue
                 callback, error_callback, start_time, next_move, _ = self.queries[query_id]
+                if "warning" in analysis:
+                    self.katrain.log(
+                        f"Warning received from KataGo: {analysis.get('warning')}",
+                        OUTPUT_DEBUG,
+                    )
                 if "error" in analysis:
                     del self.queries[query_id]
                     if error_callback:
                         error_callback(analysis)
                     elif not (next_move and "Illegal move" in analysis["error"]):  # sweep
                         self.katrain.log(f"{analysis} received from KataGo", OUTPUT_ERROR)
-                elif "warning" in analysis:
-                    self.katrain.log(f"{analysis} received from KataGo", OUTPUT_DEBUG)
                 elif "terminateId" in analysis:
                     self.katrain.log(f"{analysis} received from KataGo", OUTPUT_DEBUG)
                 else:


### PR DESCRIPTION
## Problem

The response dispatch in `katrain/core/engine.py` had `"warning"` as an `elif` branch ahead of the result-processing `else`. When KataGo emits a warning alongside an otherwise-valid response — for example `"extra non-whitespace at the end of the query"`, or various engine-side notices that come with full `moveInfos` and `rootInfo` — the warning branch matched first and the analysis data was silently logged at DEBUG level and discarded. The callback never fired and the query stayed pending in `self.queries` until something else cleared it (new game, terminate, or app restart).

A response carrying both `error` and `warning` had a related problem: the warning branch ate it before the error handler could run.

## Fix

Move the warning check out of the `if/elif` chain into an independent statement that logs the warning and falls through to the existing dispatch. Responses without a `warning` field are unaffected; the common path is identical.