### PR TITLE
v1.18.1: fix Windows/frozen-build startup crash (#824)

### DIFF
--- a/katrain/core/constants.py
+++ b/katrain/core/constants.py
@@ -1,5 +1,5 @@
 PROGRAM_NAME = "KaTrain"
-VERSION = "1.18.0"
+VERSION = "1.18.1"
 HOMEPAGE = "https://github.com/sanderland/katrain"
 CONFIG_MIN_VERSION = "1.17.0"  # keep config files from this version
 ANALYSIS_FORMAT_VERSION = "1.0"

--- a/katrain/gui/sound.py
+++ b/katrain/gui/sound.py
@@ -31,16 +31,23 @@ def preload_sounds(sound_dir):
     if not audio_files:
         return
 
-    # Test if audio subsystem works by loading one sound in a subprocess
-    try:
-        subprocess.run(
-            [sys.executable, "-c",
-             f"from kivy.core.audio import SoundLoader; SoundLoader.load({audio_files[0]!r})"],
-            timeout=3, capture_output=True,
-        )
-    except subprocess.TimeoutExpired as e:
-        print(f"Warning: Audio unavailable ({e}). Sounds disabled.", file=sys.stderr)
-        return
+    # SoundLoader.load() deadlocks when no audio output device is available, so
+    # on macOS/Linux we first probe in a subprocess. We skip the probe when:
+    #  - on Windows, where the deadlock does not occur, and
+    #  - in frozen builds, where sys.executable is the katrain app (not python),
+    #    so "-c <snippet>" relaunches katrain instead of running the snippet;
+    #    Kivy then misparses it as a "section:key:value" config arg and crashes.
+    # See https://github.com/sanderland/katrain/issues/824
+    if platform != "win" and not getattr(sys, "frozen", False):
+        try:
+            subprocess.run(
+                [sys.executable, "-c",
+                 f"from kivy.core.audio import SoundLoader; SoundLoader.load({audio_files[0]!r})"],
+                timeout=3, capture_output=True,
+            )
+        except subprocess.TimeoutExpired as e:
+            print(f"Warning: Audio unavailable ({e}). Sounds disabled.", file=sys.stderr)
+            return
 
     # Audio works, preload all sounds
     for path in audio_files:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "KaTrain"
-version = "1.18.0"
+version = "1.18.1"
 description = "Go/Baduk/Weiqi playing and teaching app with a variety of AIs"
 authors = [{ name = "Sander Land" }]
 requires-python = ">=3.10,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,10 @@ name = "KaTrain"
 version = "1.18.1"
 description = "Go/Baduk/Weiqi playing and teaching app with a variety of AIs"
 authors = [{ name = "Sander Land" }]
+# Cap tracks binary-wheel availability of kivy + ffpyplayer (no cp314 wheels yet).
+# Kivy 3.14 support is merged to master but unreleased (kivy/kivy#9225); ffpyplayer
+# 3.14 is still in progress (matham/ffpyplayer#185). Raise the cap once both ship
+# cp314 wheels. Note ffpyplayer is our direct dep (audio); kivy does not pull it.
 requires-python = ">=3.10,<3.14"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Fixes #824 — KaTrain 1.18.0 crashes on startup on Windows with:

```
configparser.NoSectionError: No section: "from kivy.core.audio import SoundLoader; SoundLoader.load('C"
```

### Cause

v1.18.0 added an audio probe in `preload_sounds()` that runs `sys.executable -c "<snippet>"` in a subprocess to detect whether the audio subsystem works before the SDL2 window is created (guarding against `SoundLoader.load()` deadlocking when there's no audio device).

In a frozen (PyInstaller) build `sys.executable` is the **katrain app**, not a Python interpreter, so `-c "<snippet>"` doesn't run the snippet — it's relaunched as `argv` and Kivy parses it as its own `-c section:key:value` config option. The first `:` lands inside the `C:\...` Windows path, so the "section" becomes the Python snippet and `Config.set()` raises `NoSectionError`.

### Fix

Skip the subprocess probe when:
- on **Windows**, where the no-audio-device deadlock doesn't occur, and
- in any **frozen build**, where the probe can't work regardless of platform.

In those cases sounds are loaded directly. The probe still runs for from-source macOS/Linux, preserving the headless/no-audio deadlock guard.

Also bumps version to **1.18.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)