### PR TITLE
Open the navigation drawer on hamburger release

### DIFF
--- a/katrain/gui.kv
+++ b/katrain/gui.kv
@@ -857,7 +857,7 @@
     HamburgerButton:
         id: hamburger
         size_hint: None, 1
-        on_press: app.gui.nav_drawer.set_state("open")
+        on_release: app.gui.nav_drawer.set_state("open")
     AnchorLayout:
         MDBoxLayout:
             adaptive_width: True


### PR DESCRIPTION
﻿## Summary

Open the navigation drawer when the hamburger button is released instead of when it is pressed.

## Problem

On Windows, a hamburger click can open the drawer on pointer-down and immediately close it again on pointer-up. The drawer's outside-click handler sees that release in the top controls, which are outside the drawer bounds.

## Fix

Bind the hamburger action to `on_release`. The drawer remains closed while the pointer gesture is active and opens only after a completed button click. Drawer closing behavior, animation, configuration, and translations are unchanged.

## Validation

- `CI=true python -m pytest tests`: 30 passed, 1 skipped (OpenCL-only test)
- `python i18n.py -todo`: passed
- Parsed `katrain/gui.kv` with Kivy 2.3.1: passed
- `git diff --check`: passed

Manual Windows verification is still appropriate for the pointer interaction itself.
