### PR TITLE
Use native OS file dialogs for loading and saving SGF files

### DIFF
--- a/katrain/__main__.py
+++ b/katrain/__main__.py
@@ -104,6 +104,7 @@ from katrain.core.contribute_engine import KataGoContributeEngine
 from katrain.core.game import Game, IllegalMoveException, KaTrainSGF, BaseGame
 from katrain.core.sgf_parser import Move, ParseError
 from katrain.gui.popups import ConfigPopup, LoadSGFPopup, NewGamePopup, ConfigAIPopup
+from katrain.gui import nativefiledialog
 from katrain.gui.theme import Theme
 from kivymd.app import MDApp
 
@@ -588,28 +589,55 @@ class KaTrainGui(Screen, KaTrainBase):
             self.game.redo(999)
 
     def _do_analyze_sgf_popup(self):
-        if not self.fileselect_popup:
-            popup_contents = LoadSGFPopup(self)
-            popup_contents.filesel.path = os.path.abspath(os.path.expanduser(self.config("general/sgf_load", ".")))
-            self.fileselect_popup = I18NPopup(
-                title_key="load sgf title", size=[dp(1200), dp(800)], content=popup_contents
-            ).__self__
+        def open_kivy_popup():
+            if not self.fileselect_popup:
+                popup_contents = LoadSGFPopup(self)
+                popup_contents.filesel.path = os.path.abspath(os.path.expanduser(self.config("general/sgf_load", ".")))
+                self.fileselect_popup = I18NPopup(
+                    title_key="load sgf title", size=[dp(1200), dp(800)], content=popup_contents
+                ).__self__
 
-            def readfile(*_args):
-                filename = popup_contents.filesel.filename
-                self.fileselect_popup.dismiss()
-                path, file = os.path.split(filename)
-                if path != self.config("general/sgf_load"):
-                    self.log(f"Updating sgf load path default to {path}", OUTPUT_DEBUG)
-                    self._config["general"]["sgf_load"] = path
-                popup_contents.update_config(False)
+                def readfile(*_args):
+                    filename = popup_contents.filesel.filename
+                    self.fileselect_popup.dismiss()
+                    path, file = os.path.split(filename)
+                    if path != self.config("general/sgf_load"):
+                        self.log(f"Updating sgf load path default to {path}", OUTPUT_DEBUG)
+                        self._config["general"]["sgf_load"] = path
+                    popup_contents.update_config(False)
+                    self.save_config("general")
+                    self.load_sgf_file(filename, popup_contents.fast.active, popup_contents.rewind.active)
+
+                popup_contents.filesel.on_success = readfile
+                popup_contents.filesel.on_submit = readfile
+            self.fileselect_popup.open()
+            self.fileselect_popup.content.filesel.ids.list_view._trigger_update()
+
+        if not nativefiledialog.available():
+            open_kivy_popup()
+            return
+
+        def on_load_file(filename):
+            if not filename:
+                return
+            path, _file = os.path.split(filename)
+            if path != self.config("general/sgf_load"):
+                self.log(f"Updating sgf load path default to {path}", OUTPUT_DEBUG)
+                self._config["general"]["sgf_load"] = path
                 self.save_config("general")
-                self.load_sgf_file(filename, popup_contents.fast.active, popup_contents.rewind.active)
+            self.load_sgf_file(
+                filename,
+                fast=self.config("general/load_fast_analysis", False),
+                rewind=self.config("general/load_sgf_rewind", True),
+            )
 
-            popup_contents.filesel.on_success = readfile
-            popup_contents.filesel.on_submit = readfile
-        self.fileselect_popup.open()
-        self.fileselect_popup.content.filesel.ids.list_view._trigger_update()
+        nativefiledialog.open_file(
+            on_load_file,
+            error_callback=open_kivy_popup,
+            prompt=i18n._("load sgf title"),
+            initial_dir=self.config("general/sgf_load", "."),
+            extensions=["sgf", "gib", "ngf"],
+        )
 
     def _do_save_game(self, filename=None):
         filename = filename or self.game.sgf_filename
@@ -623,28 +651,54 @@ class KaTrainGui(Screen, KaTrainBase):
             self.log(f"Failed to save SGF to {filename}: {e}", OUTPUT_ERROR)
 
     def _do_save_game_as_popup(self):
-        popup_contents = SaveSGFPopup(suggested_filename=self.game.generate_filename())
-        save_game_popup = I18NPopup(
-            title_key="save sgf title", size=[dp(1200), dp(800)], content=popup_contents
-        ).__self__
+        def open_kivy_popup():
+            popup_contents = SaveSGFPopup(suggested_filename=self.game.generate_filename())
+            save_game_popup = I18NPopup(
+                title_key="save sgf title", size=[dp(1200), dp(800)], content=popup_contents
+            ).__self__
 
-        def readfile(*_args):
-            filename = popup_contents.filesel.filename
+            def readfile(*_args):
+                filename = popup_contents.filesel.filename
+                if not filename.lower().endswith(".sgf"):
+                    filename += ".sgf"
+                save_game_popup.dismiss()
+                path, file = os.path.split(filename.strip())
+                if not path:
+                    path = popup_contents.filesel.path  # whatever dir is shown
+                if path != self.config("general/sgf_save"):
+                    self.log(f"Updating sgf save path default to {path}", OUTPUT_DEBUG)
+                    self._config["general"]["sgf_save"] = path
+                    self.save_config("general")
+                self._do_save_game(os.path.join(path, file))
+
+            popup_contents.filesel.on_success = readfile
+            popup_contents.filesel.on_submit = readfile
+            save_game_popup.open()
+
+        if not nativefiledialog.available():
+            open_kivy_popup()
+            return
+
+        def on_save_file(filename):
+            if not filename:
+                return
             if not filename.lower().endswith(".sgf"):
                 filename += ".sgf"
-            save_game_popup.dismiss()
             path, file = os.path.split(filename.strip())
-            if not path:
-                path = popup_contents.filesel.path  # whatever dir is shown
             if path != self.config("general/sgf_save"):
                 self.log(f"Updating sgf save path default to {path}", OUTPUT_DEBUG)
                 self._config["general"]["sgf_save"] = path
                 self.save_config("general")
             self._do_save_game(os.path.join(path, file))
 
-        popup_contents.filesel.on_success = readfile
-        popup_contents.filesel.on_submit = readfile
-        save_game_popup.open()
+        nativefiledialog.save_file(
+            on_save_file,
+            error_callback=open_kivy_popup,
+            prompt=i18n._("save sgf title"),
+            initial_dir=self.config("general/sgf_save", "."),
+            suggested_name=self.game.generate_filename(),
+            extensions=["sgf"],
+        )
 
     def load_sgf_from_clipboard(self):
         clipboard = Clipboard.paste()

--- a/katrain/gui/nativefiledialog.py
+++ b/katrain/gui/nativefiledialog.py
@@ -1,0 +1,225 @@
+"""Native OS file open/save dialogs.
+
+Uses osascript (macOS), the comdlg32 API via ctypes (Windows) or
+zenity/kdialog (Linux) to show the platform's own file dialog instead of
+the in-app Kivy FileBrowser. Dialogs run in a background thread so the
+Kivy event loop keeps running; the result (a path, or None on cancel) is
+delivered to the callback on the Kivy main thread. If the dialog fails to
+show, error_callback is called instead, so callers can fall back to the
+Kivy FileBrowser popup. Callers should check available() first and use
+the popup directly when it returns False.
+"""
+
+import os
+import shutil
+import subprocess
+import threading
+
+from kivy.clock import Clock
+from kivy.logger import Logger
+from kivy.utils import platform as kivy_platform
+
+_dialog_lock = threading.Lock()
+_dialog_open = False
+
+
+def available() -> bool:
+    if kivy_platform in ("macosx", "win"):
+        return True
+    if kivy_platform == "linux":
+        return shutil.which("zenity") is not None or shutil.which("kdialog") is not None
+    return False
+
+
+def open_file(callback, error_callback=None, prompt="", initial_dir=None, extensions=None):
+    """Show a native 'open file' dialog, then call callback(path_or_None) on the main thread."""
+    initial_dir = _existing_dir(initial_dir)
+    _launch(callback, error_callback, lambda: _open_impl(prompt, initial_dir, extensions or []))
+
+
+def save_file(callback, error_callback=None, prompt="", initial_dir=None, suggested_name="", extensions=None):
+    """Show a native 'save file' dialog, then call callback(path_or_None) on the main thread."""
+    initial_dir = _existing_dir(initial_dir)
+    _launch(callback, error_callback, lambda: _save_impl(prompt, initial_dir, suggested_name, extensions or []))
+
+
+class DialogError(Exception):
+    pass
+
+
+def _existing_dir(path):
+    if path:
+        path = os.path.abspath(os.path.expanduser(path))
+        while path and not os.path.isdir(path):
+            parent = os.path.dirname(path)
+            if parent == path:
+                break
+            path = parent
+    return path if path and os.path.isdir(path) else os.path.expanduser("~")
+
+
+def _launch(callback, error_callback, dialog_fn):
+    global _dialog_open
+    with _dialog_lock:
+        if _dialog_open:  # a dialog is already showing, ignore repeated requests
+            return
+        _dialog_open = True
+
+    def worker():
+        global _dialog_open
+        result, failed = None, False
+        try:
+            result = dialog_fn()
+        except Exception as e:
+            Logger.warning(f"nativefiledialog: dialog failed: {e}")
+            failed = True
+        finally:
+            with _dialog_lock:
+                _dialog_open = False
+        if failed and error_callback:
+            Clock.schedule_once(lambda _dt: error_callback())
+        else:
+            Clock.schedule_once(lambda _dt: callback(result))
+
+    threading.Thread(target=worker, daemon=True).start()
+
+
+def _open_impl(prompt, initial_dir, extensions):
+    if kivy_platform == "macosx":
+        return _macos_dialog(f"choose file with prompt {_as_quote(prompt)}", initial_dir)
+    if kivy_platform == "win":
+        return _win_dialog(False, prompt, initial_dir, "", extensions)
+    return _linux_dialog(False, prompt, initial_dir, "", extensions)
+
+
+def _save_impl(prompt, initial_dir, suggested_name, extensions):
+    if kivy_platform == "macosx":
+        script = f"choose file name with prompt {_as_quote(prompt)}"
+        if suggested_name:
+            script += f" default name {_as_quote(suggested_name)}"
+        return _macos_dialog(script, initial_dir)
+    if kivy_platform == "win":
+        return _win_dialog(True, prompt, initial_dir, suggested_name, extensions)
+    return _linux_dialog(True, prompt, initial_dir, suggested_name, extensions)
+
+
+# -- macOS ---------------------------------------------------------------
+
+
+def _as_quote(s):
+    return '"' + str(s).replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _macos_dialog(choose_script, initial_dir):
+    # no 'of type' filter: extensions like .sgf have no registered UTI, which would gray out all files
+    if initial_dir:
+        choose_script += f" default location POSIX file {_as_quote(initial_dir)}"
+    result = subprocess.run(["osascript", "-e", f"POSIX path of ({choose_script})"], capture_output=True, text=True)
+    if result.returncode != 0:
+        if "-128" in result.stderr:  # User canceled
+            return None
+        raise DialogError(result.stderr.strip() or f"osascript exited {result.returncode}")
+    return result.stdout.strip() or None
+
+
+# -- Windows -------------------------------------------------------------
+
+
+def _win_dialog(save, prompt, initial_dir, suggested_name, extensions):
+    import ctypes
+    import ctypes.wintypes as w
+
+    class OPENFILENAMEW(ctypes.Structure):
+        _fields_ = [
+            ("lStructSize", w.DWORD),
+            ("hwndOwner", w.HWND),
+            ("hInstance", w.HINSTANCE),
+            ("lpstrFilter", w.LPCWSTR),
+            ("lpstrCustomFilter", w.LPWSTR),
+            ("nMaxCustFilter", w.DWORD),
+            ("nFilterIndex", w.DWORD),
+            ("lpstrFile", w.LPWSTR),
+            ("nMaxFile", w.DWORD),
+            ("lpstrFileTitle", w.LPWSTR),
+            ("nMaxFileTitle", w.DWORD),
+            ("lpstrInitialDir", w.LPCWSTR),
+            ("lpstrTitle", w.LPCWSTR),
+            ("Flags", w.DWORD),
+            ("nFileOffset", w.WORD),
+            ("nFileExtension", w.WORD),
+            ("lpstrDefExt", w.LPCWSTR),
+            ("lCustData", w.LPARAM),
+            ("lpfnHook", ctypes.c_void_p),
+            ("lpTemplateName", w.LPCWSTR),
+            ("pvReserved", ctypes.c_void_p),
+            ("dwReserved", w.DWORD),
+            ("FlagsEx", w.DWORD),
+        ]
+
+    OFN_EXPLORER = 0x00080000
+    OFN_PATHMUSTEXIST = 0x00000800
+    OFN_FILEMUSTEXIST = 0x00001000
+    OFN_HIDEREADONLY = 0x00000004
+    OFN_NOCHANGEDIR = 0x00000008  # keep cwd stable, engine/model paths are relative to it
+    OFN_OVERWRITEPROMPT = 0x00000002
+
+    if extensions:
+        patterns = ";".join(f"*.{e}" for e in extensions)
+        filters = f"Supported files ({patterns})\0{patterns}\0All files (*.*)\0*.*\0"
+    else:
+        filters = "All files (*.*)\0*.*\0"
+
+    file_buffer = ctypes.create_unicode_buffer(suggested_name, 65536)
+    ofn = OPENFILENAMEW()
+    ofn.lStructSize = ctypes.sizeof(OPENFILENAMEW)
+    ofn.lpstrFilter = filters
+    ofn.lpstrFile = ctypes.cast(file_buffer, w.LPWSTR)
+    ofn.nMaxFile = 65536
+    ofn.lpstrInitialDir = initial_dir or None
+    ofn.lpstrTitle = prompt or None
+    ofn.Flags = OFN_EXPLORER | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY | OFN_NOCHANGEDIR
+    if save:
+        ofn.Flags |= OFN_OVERWRITEPROMPT
+        ofn.lpstrDefExt = extensions[0] if extensions else None
+    else:
+        ofn.Flags |= OFN_FILEMUSTEXIST
+
+    dialog = ctypes.windll.comdlg32.GetSaveFileNameW if save else ctypes.windll.comdlg32.GetOpenFileNameW
+    if not dialog(ctypes.byref(ofn)):
+        error = ctypes.windll.comdlg32.CommDlgExtendedError()
+        if error:
+            raise DialogError(f"comdlg32 dialog failed with error 0x{error:x}")
+        return None  # user canceled
+    return file_buffer.value or None
+
+
+# -- Linux ---------------------------------------------------------------
+
+
+def _linux_dialog(save, prompt, initial_dir, suggested_name, extensions):
+    if shutil.which("zenity"):
+        cmd = ["zenity", "--file-selection", f"--title={prompt}"]
+        if save:
+            cmd.append("--save")
+            if initial_dir or suggested_name:
+                cmd.append(f"--filename={os.path.join(initial_dir or '', suggested_name)}")
+        elif initial_dir:
+            cmd.append(f"--filename={initial_dir.rstrip(os.sep)}{os.sep}")
+        if extensions:
+            cmd.append("--file-filter=" + " ".join(f"*.{e}" for e in extensions))
+            cmd.append("--file-filter=*")
+        cancel_codes = (1,)
+    elif shutil.which("kdialog"):
+        cmd = ["kdialog", "--title", prompt, "--getsavefilename" if save else "--getopenfilename"]
+        cmd.append(os.path.join(initial_dir or os.path.expanduser("~"), suggested_name if save else ""))
+        if extensions:
+            cmd.append(" ".join(f"*.{e}" for e in extensions) + "|Supported files")
+        cancel_codes = (1,)
+    else:
+        raise DialogError("neither zenity nor kdialog found")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        if result.returncode in cancel_codes:
+            return None
+        raise DialogError(result.stderr.strip() or f"{cmd[0]} exited {result.returncode}")
+    return result.stdout.strip() or None

--- a/katrain/popups.kv
+++ b/katrain/popups.kv
@@ -352,6 +352,20 @@
                     input_property: "ui_state/restoresize"
 
             DescriptionLabel:
+                text: i18n._("load sgf fast analysis")
+                size_hint_x: 1.5
+            AnchorLayout:
+                LabelledCheckBox:
+                    input_property: "general/load_fast_analysis"
+
+            DescriptionLabel:
+                text: i18n._("load sgf rewind")
+                size_hint_x: 1.5
+            AnchorLayout:
+                LabelledCheckBox:
+                    input_property: "general/load_sgf_rewind"
+
+            DescriptionLabel:
                 text: i18n._("general:debug_level")
                 size_hint_x: 1.5
             AnchorLayout:


### PR DESCRIPTION
Hi! First of all, thank you for KaTrain. I recently started learning Go, and KaTrain quickly became the tool I use every day to review my games — I really appreciate all the work that has gone into it.

One small thing I kept bumping into is the in-app file browser: compared to the OS file dialog it's a bit hard to use (small hit targets, manual path typing, no access to the system's own shortcuts and recent folders). This PR switches the load-SGF and save-as flows to the platform's native file dialogs, while keeping the existing Kivy FileBrowser as a fallback so no platform loses functionality.

## What's changed

- New `katrain/gui/nativefiledialog.py` module:
  - **macOS**: `osascript` (NSOpenPanel / NSSavePanel) — no new dependencies
  - **Windows**: `comdlg32` `GetOpenFileNameW` / `GetSaveFileNameW` via ctypes — works in the PyInstaller builds too (tkinter would not, since Kivy's pyinstaller hooks exclude it)
  - **Linux**: `zenity` if present, else `kdialog`; with neither installed, `available()` returns False and the existing in-app browser opens exactly as before
- Dialogs run on a background thread so the Kivy event loop keeps running; results are delivered on the main thread via `Clock`. Repeated open requests while a dialog is showing are ignored, and if the native dialog fails at runtime the old Kivy popup opens as a fallback.
- The "fast analysis" / "rewind" checkboxes from the load popup are now also available in General Settings, since the native dialog path reads them from config (the fallback popup keeps its own checkboxes).
- Last-used load/save directory behavior is unchanged.

## Notes / trade-offs

- The macOS open dialog does not filter by extension: AppleScript's `of type` needs registered UTIs, and `.sgf`/`.gib`/`.ngf` usually have none, which would gray out every file. All files stay selectable; picking a non-SGF fails to parse with the usual status-bar error, same as typing a wrong filename before.
- Overwrite confirmation on save now comes from the OS dialog (the in-app browser did not ask).

## Testing

- **macOS** (Apple Silicon, from source): open/save/cancel, extension appending, directory memory
- **Windows** (PyInstaller frozen build from this branch's CI): native open/save dialogs show with the `*.sgf;*.gib;*.ngf` filter, overwrite prompt works, cancel is a no-op
- **Linux**: code path reviewed; without zenity/kdialog there is no behavior change (falls back to the current browser)

Happy to adjust anything — for example adding a config option to keep the in-app browser, or changing where the load options live in settings. Thanks for taking a look!

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01H2ZHfccgtBTUQZLQkMj6oE