### PR TITLE
Replace black with ruff, and enforce lint and import sorting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-# line length, space before binary op, line break before binary op, import not at top
-ignore = E501, E203, W503, E402
-exclude = .git,__pycache__,build,dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+# Run `uv run pre-commit install` once to enable. CI enforces the same checks.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.8
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format

--- a/katrain/__main__.py
+++ b/katrain/__main__.py
@@ -9,7 +9,7 @@ os.environ["KCFG_KIVY_LOG_LEVEL"] = os.environ.get("KCFG_KIVY_LOG_LEVEL", "warni
 from kivy.utils import platform as kivy_platform
 
 if kivy_platform == "win":
-    from ctypes import windll, c_int64
+    from ctypes import c_int64, windll
 
     if hasattr(windll.user32, "SetProcessDpiAwarenessContext"):
         windll.user32.SetProcessDpiAwarenessContext(c_int64(-4))
@@ -19,8 +19,9 @@ import kivy
 kivy.require("2.0.0")
 
 # next, icon
-from katrain.core.utils import find_package_resource, PATHS
 from kivy.config import Config
+
+from katrain.core.utils import PATHS, find_package_resource
 
 if kivy_platform == "macosx":
     ICON = find_package_resource("katrain/img/icon.icns")
@@ -43,75 +44,81 @@ if getattr(sys, "frozen", False):
         os.environ["SSL_CERT_FILE"] = os.path.join(sys._MEIPASS, "certifi", "cacert.pem")
 
 
+import glob
+import json
+import random
 import re
 import signal
-import json
 import threading
-import traceback
-from queue import Queue
-import urllib3
-import webbrowser
 import time
-import random
-import glob
+import traceback
+import webbrowser
+from queue import Queue
 
-from kivy.base import ExceptionHandler, ExceptionManager
+import urllib3
 from kivy.app import App
+from kivy.base import ExceptionHandler, ExceptionManager
+from kivy.clock import Clock
 from kivy.core.clipboard import Clipboard
+from kivy.core.window import Window
 from kivy.lang import Builder
-from kivy.resources import resource_add_path
+from kivy.metrics import dp
+from kivy.properties import NumericProperty, ObjectProperty, StringProperty
+from kivy.resources import resource_add_path, resource_find
 from kivy.uix.popup import Popup
 from kivy.uix.screenmanager import Screen
-from kivy.core.window import Window
 from kivy.uix.widget import Widget
-from kivy.resources import resource_find
-from kivy.properties import NumericProperty, ObjectProperty, StringProperty
-from kivy.clock import Clock
-from kivy.metrics import dp
-from katrain.core.ai import generate_ai_move
-
-from katrain.core.lang import DEFAULT_LANGUAGE, i18n
-from katrain.core.constants import (
-    OUTPUT_ERROR,
-    OUTPUT_KATAGO_STDERR,
-    OUTPUT_INFO,
-    OUTPUT_DEBUG,
-    OUTPUT_EXTRA_DEBUG,
-    MODE_ANALYZE,
-    HOMEPAGE,
-    VERSION,
-    STATUS_ERROR,
-    STATUS_INFO,
-    PLAYING_NORMAL,
-    PLAYER_HUMAN,
-    SGF_INTERNAL_COMMENTS_MARKER,
-    MODE_PLAY,
-    DATA_FOLDER,
-    AI_DEFAULT,
-)
-from katrain.gui.popups import (
-    ConfigTeacherPopup,
-    ConfigTimerPopup,
-    I18NPopup,
-    SaveSGFPopup,
-    ContributePopup,
-    EngineRecoveryPopup,
-)
-from katrain.gui.sound import play_sound
-from katrain.core.base_katrain import KaTrainBase
-from katrain.core.remote_engine import make_engine
-from katrain.core.contribute_engine import KataGoContributeEngine
-from katrain.core.game import Game, IllegalMoveException, KaTrainSGF, BaseGame
-from katrain.core.sgf_parser import Move, ParseError
-from katrain.gui.popups import ConfigPopup, LoadSGFPopup, NewGamePopup, ConfigAIPopup
-from katrain.gui.theme import Theme
 from kivymd.app import MDApp
 
+from katrain.core.ai import generate_ai_move
+from katrain.core.base_katrain import KaTrainBase
+from katrain.core.constants import (
+    AI_DEFAULT,
+    DATA_FOLDER,
+    HOMEPAGE,
+    MODE_ANALYZE,
+    MODE_PLAY,
+    OUTPUT_DEBUG,
+    OUTPUT_ERROR,
+    OUTPUT_EXTRA_DEBUG,
+    OUTPUT_INFO,
+    OUTPUT_KATAGO_STDERR,
+    PLAYER_AI,
+    PLAYER_HUMAN,
+    PLAYING_NORMAL,
+    SGF_INTERNAL_COMMENTS_MARKER,
+    STATUS_ERROR,
+    STATUS_INFO,
+    VERSION,
+)
+from katrain.core.contribute_engine import KataGoContributeEngine
+from katrain.core.game import BaseGame, Game, IllegalMoveException, KaTrainSGF
+from katrain.core.lang import DEFAULT_LANGUAGE, i18n
+from katrain.core.remote_engine import make_engine
+from katrain.core.sgf_parser import Move, ParseError
+from katrain.gui.badukpan import AnalysisControls, BadukPanControls, BadukPanWidget  # noqa: F401
+from katrain.gui.controlspanel import ControlsPanel  # noqa: F401
+
 # used in kv
-from katrain.gui.kivyutils import *
-from katrain.gui.widgets import MoveTree, I18NFileBrowser, SelectionSlider, ScoreGraph  # noqa F401
-from katrain.gui.badukpan import AnalysisControls, BadukPanControls, BadukPanWidget  # noqa F401
-from katrain.gui.controlspanel import ControlsPanel  # noqa F401
+# Star import kept deliberately: importing these classes registers them with Kivy's
+# Factory, which is how the .kv files resolve them by name.
+from katrain.gui.kivyutils import *  # noqa: F403
+from katrain.gui.kivyutils import PlayerSetupBlock
+from katrain.gui.popups import (
+    ConfigAIPopup,
+    ConfigPopup,
+    ConfigTeacherPopup,
+    ConfigTimerPopup,
+    ContributePopup,
+    EngineRecoveryPopup,
+    I18NPopup,
+    LoadSGFPopup,
+    NewGamePopup,
+    SaveSGFPopup,
+)
+from katrain.gui.sound import play_sound
+from katrain.gui.theme import Theme
+from katrain.gui.widgets import I18NFileBrowser, MoveTree, ScoreGraph, SelectionSlider  # noqa: F401
 
 
 class KaTrainGui(Screen, KaTrainBase):
@@ -823,6 +830,7 @@ class KaTrainGui(Screen, KaTrainBase):
             self.log("starting profiler", OUTPUT_ERROR)
         elif keycode[1] == "f11" and self.debug_level >= OUTPUT_EXTRA_DEBUG:
             import time
+
             import yappi
 
             stats = yappi.get_func_stats()
@@ -876,7 +884,7 @@ class KaTrainApp(MDApp):
                 ):
                     return True
             return False
-        except Exception as e:
+        except Exception:
             return True  # yolo
 
     def build(self):
@@ -902,7 +910,7 @@ class KaTrainApp(MDApp):
                 for k, v in theme_overrides.items():
                     setattr(Theme, k, v)
                     print(f"[{theme_file}] Found theme override {k} = {v}")
-            except Exception as e:  # noqa E722
+            except Exception as e:
                 print(f"Failed to load theme file {theme_file}: {e}")
 
         Theme.DEFAULT_FONT = resource_find(Theme.DEFAULT_FONT)
@@ -925,7 +933,7 @@ class KaTrainApp(MDApp):
 
                 for m in get_monitors():
                     window_scale_fac = min(window_scale_fac, (m.height - 100) / 1000, (m.width - 100) / 1300)
-            except Exception as e:
+            except Exception:
                 window_scale_fac = 0.85
             win_size = [1300 * window_scale_fac, 1000 * window_scale_fac]
         self.gui.log(f"Setting window size to {win_size} and position to {[win_left, win_top]}", OUTPUT_DEBUG)

--- a/katrain/core/ai.py
+++ b/katrain/core/ai.py
@@ -1,30 +1,55 @@
-from abc import ABC, abstractmethod
 import heapq
 import math
-import random
 import time
+from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Tuple
 
 from katrain.core.constants import (
-    AI_DEFAULT, AI_HANDICAP, AI_INFLUENCE, AI_INFLUENCE_ELO_GRID, AI_JIGO,
-    AI_ANTIMIRROR, AI_LOCAL, AI_LOCAL_ELO_GRID, AI_PICK, AI_PICK_ELO_GRID,
-    AI_POLICY, AI_RANK, AI_SCORELOSS, AI_SCORELOSS_ELO, AI_SETTLE_STONES,
-    AI_SIMPLE_OWNERSHIP, AI_STRENGTH,
-    AI_TENUKI, AI_TENUKI_ELO_GRID, AI_TERRITORY, AI_TERRITORY_ELO_GRID,
-    AI_WEIGHTED, AI_WEIGHTED_ELO, CALIBRATED_RANK_ELO, OUTPUT_DEBUG,
-    OUTPUT_ERROR, OUTPUT_INFO, PRIORITY_EXTRA_AI_QUERY, ADDITIONAL_MOVE_ORDER, AI_HUMAN, AI_PRO
+    ADDITIONAL_MOVE_ORDER,
+    AI_ANTIMIRROR,
+    AI_DEFAULT,
+    AI_HANDICAP,
+    AI_HUMAN,
+    AI_INFLUENCE,
+    AI_INFLUENCE_ELO_GRID,
+    AI_JIGO,
+    AI_LOCAL,
+    AI_LOCAL_ELO_GRID,
+    AI_PICK,
+    AI_PICK_ELO_GRID,
+    AI_POLICY,
+    AI_PRO,
+    AI_RANK,
+    AI_SCORELOSS,
+    AI_SCORELOSS_ELO,
+    AI_SETTLE_STONES,
+    AI_SIMPLE_OWNERSHIP,
+    AI_STRENGTH,
+    AI_TENUKI,
+    AI_TENUKI_ELO_GRID,
+    AI_TERRITORY,
+    AI_TERRITORY_ELO_GRID,
+    AI_WEIGHTED,
+    AI_WEIGHTED_ELO,
+    CALIBRATED_RANK_ELO,
+    OUTPUT_DEBUG,
+    OUTPUT_ERROR,
+    PRIORITY_EXTRA_AI_QUERY,
 )
 from katrain.core.game import Game, GameNode, Move
-from katrain.core.utils import var_to_grid, weighted_selection_without_replacement, evaluation_class
+from katrain.core.utils import evaluation_class, var_to_grid, weighted_selection_without_replacement
 
 # Decorator pattern for adding classes to the registry
 STRATEGY_REGISTRY = {}
+
 
 def register_strategy(strategy_name):
     def decorator(strategy_class):
         STRATEGY_REGISTRY[strategy_name] = strategy_class
         return strategy_class
+
     return decorator
+
 
 def interp_ix(lst, x):
     i = 0
@@ -33,10 +58,12 @@ def interp_ix(lst, x):
     t = max(0, min(1, (x - lst[i]) / (lst[i + 1] - lst[i])))
     return i, t
 
+
 def interp1d(lst, x):
     xs, ys = zip(*lst)
     i, t = interp_ix(xs, x)
     return (1 - t) * ys[i] + t * ys[i + 1]
+
 
 def interp2d(gridspec, x, y):
     xs, ys, matrix = gridspec
@@ -48,6 +75,7 @@ def interp2d(gridspec, x, y):
         + matrix[j + 1][i] * (1 - t) * s
         + matrix[j + 1][i + 1] * t * s
     )
+
 
 def ai_rank_estimation(strategy, settings) -> int:
     if strategy in [AI_DEFAULT, AI_HANDICAP, AI_JIGO, AI_PRO]:
@@ -77,6 +105,7 @@ def ai_rank_estimation(strategy, settings) -> int:
         return 1 - kyu
     else:
         return AI_STRENGTH[strategy]
+
 
 def game_report(game, thresholds, depth_filter=None):
     cn = game.current_node
@@ -142,8 +171,10 @@ def game_report(game, thresholds, depth_filter=None):
     }
     return sum_stats, histogram, player_ptloss
 
+
 def fmt_moves(moves: List[Tuple[float, Move]]):
     return ", ".join(f"{mv.gtp()} ({p:.2%})" for p, mv in moves)
+
 
 # Utility functions from the original code
 def policy_weighted_move(policy_moves, lower_bound, weaken_fac):
@@ -160,16 +191,21 @@ def policy_weighted_move(policy_moves, lower_bound, weaken_fac):
         ai_thoughts = f"Playing top policy move because no non-pass move > above lower_bound of {lower_bound:.1%}."
     return move, ai_thoughts
 
+
 def generate_influence_territory_weights(ai_mode, ai_settings, policy_grid, size):
     thr_line = ai_settings["threshold"] - 1  # zero-based
     if ai_mode == AI_INFLUENCE:
-        weight = lambda x, y: (1 / ai_settings["line_weight"]) ** (  # noqa E731
-            max(0, thr_line - min(size[0] - 1 - x, x)) + max(0, thr_line - min(size[1] - 1 - y, y))
-        )  # noqa E731
+
+        def weight(x, y):
+            return (1 / ai_settings["line_weight"]) ** (
+                max(0, thr_line - min(size[0] - 1 - x, x)) + max(0, thr_line - min(size[1] - 1 - y, y))
+            )
+
     else:
-        weight = lambda x, y: (1 / ai_settings["line_weight"]) ** (  # noqa E731
-            max(0, min(size[0] - 1 - x, x, size[1] - 1 - y, y) - thr_line)
-        )
+
+        def weight(x, y):
+            return (1 / ai_settings["line_weight"]) ** max(0, min(size[0] - 1 - x, x, size[1] - 1 - y, y) - thr_line)
+
     weighted_coords = [
         (policy_grid[y][x] * weight(x, y), weight(x, y), x, y)
         for x in range(size[0])
@@ -178,6 +214,7 @@ def generate_influence_territory_weights(ai_mode, ai_settings, policy_grid, size
     ]
     ai_thoughts = f"Generated weights for {ai_mode} according to weight factor {ai_settings['line_weight']} and distance from {thr_line + 1}th line. "
     return weighted_coords, ai_thoughts
+
 
 def generate_local_tenuki_weights(ai_mode, ai_settings, policy_grid, cn, size):
     var = ai_settings["stddev"] ** 2
@@ -196,24 +233,27 @@ def generate_local_tenuki_weights(ai_mode, ai_settings, policy_grid, cn, size):
         )
     return weighted_coords, ai_thoughts
 
+
 class AIStrategy(ABC):
     """Base strategy class for AI move generation"""
-    
+
     def __init__(self, game: Game, ai_settings: Dict):
         self.game = game
         self.settings = ai_settings
         self.cn = game.current_node
         self.strategy_name = self.__class__.__name__
         self.game.katrain.log(f"Initializing {self.strategy_name} with settings: {self.settings}", OUTPUT_DEBUG)
-        
+
     @abstractmethod
     def generate_move(self) -> Tuple[Move, str]:
         """Generate a move and explanation"""
         pass
-    
+
     def request_analysis(self, extra_settings: Dict) -> Optional[Dict]:
         """Helper to request additional analysis with custom settings"""
-        self.game.katrain.log(f"[{self.strategy_name}] Requesting analysis with settings: {extra_settings}", OUTPUT_DEBUG)
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Requesting analysis with settings: {extra_settings}", OUTPUT_DEBUG
+        )
         error = False
         analysis = None
 
@@ -241,11 +281,11 @@ class AIStrategy(ABC):
         while not (error or analysis):
             time.sleep(0.01)  # TODO: prevent deadlock if esc, check node in queries?
             engine.check_alive(exception_if_dead=True)
-        
+
         if analysis:
             self.game.katrain.log(f"[{self.strategy_name}] Analysis completed successfully", OUTPUT_DEBUG)
         return analysis
-    
+
     def wait_for_analysis(self):
         """Wait for the analysis to complete"""
         self.game.katrain.log(f"[{self.strategy_name}] Waiting for regular analysis to complete...", OUTPUT_DEBUG)
@@ -253,289 +293,344 @@ class AIStrategy(ABC):
             time.sleep(0.01)
             self.game.engines[self.cn.next_player].check_alive(exception_if_dead=True)
         self.game.katrain.log(f"[{self.strategy_name}] Regular analysis completed", OUTPUT_DEBUG)
-    
+
     def should_play_top_move(self, policy_moves, top_5_pass, override=0.0, overridetwo=1.0):
         """Check if we should play the top policy move, regardless of strategy"""
         top_policy_move = policy_moves[0][1]
-        self.game.katrain.log(f"[{self.strategy_name}] Checking if should play top move. Top move: {top_policy_move.gtp()} ({policy_moves[0][0]:.2%})", OUTPUT_DEBUG)
-        self.game.katrain.log(f"[{self.strategy_name}] Override thresholds: single={override:.2%}, combined={overridetwo:.2%}", OUTPUT_DEBUG)
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Checking if should play top move. Top move: {top_policy_move.gtp()} ({policy_moves[0][0]:.2%})",
+            OUTPUT_DEBUG,
+        )
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Override thresholds: single={override:.2%}, combined={overridetwo:.2%}",
+            OUTPUT_DEBUG,
+        )
         self.game.katrain.log(f"[{self.strategy_name}] Top 5 pass: {top_5_pass}", OUTPUT_DEBUG)
-        
+
         if top_5_pass:
             self.game.katrain.log(f"[{self.strategy_name}] Playing top move because pass is in top 5", OUTPUT_DEBUG)
             return top_policy_move, "Playing top one because one of them is pass."
-        
+
         if policy_moves[0][0] > override:
-            self.game.katrain.log(f"[{self.strategy_name}] Playing top move because weight {policy_moves[0][0]:.2%} > override {override:.2%}", OUTPUT_DEBUG)
+            self.game.katrain.log(
+                f"[{self.strategy_name}] Playing top move because weight {policy_moves[0][0]:.2%} > override {override:.2%}",
+                OUTPUT_DEBUG,
+            )
             return top_policy_move, f"Top policy move has weight > {override:.1%}, so overriding other strategies."
-            
+
         if policy_moves[0][0] + policy_moves[1][0] > overridetwo:
             combined = policy_moves[0][0] + policy_moves[1][0]
-            self.game.katrain.log(f"[{self.strategy_name}] Playing top move because combined weight {combined:.2%} > overridetwo {overridetwo:.2%}", OUTPUT_DEBUG)
-            return top_policy_move, f"Top two policy moves have cumulative weight > {overridetwo:.1%}, so overriding other strategies."
-        
-        self.game.katrain.log(f"[{self.strategy_name}] No override condition met, continuing with strategy", OUTPUT_DEBUG)    
+            self.game.katrain.log(
+                f"[{self.strategy_name}] Playing top move because combined weight {combined:.2%} > overridetwo {overridetwo:.2%}",
+                OUTPUT_DEBUG,
+            )
+            return (
+                top_policy_move,
+                f"Top two policy moves have cumulative weight > {overridetwo:.1%}, so overriding other strategies.",
+            )
+
+        self.game.katrain.log(
+            f"[{self.strategy_name}] No override condition met, continuing with strategy", OUTPUT_DEBUG
+        )
         return None, ""
+
 
 @register_strategy(AI_DEFAULT)
 class DefaultStrategy(AIStrategy):
     """Default strategy - simply plays the top move from the engine"""
-    
+
     def generate_move(self) -> Tuple[Move, str]:
-        self.game.katrain.log(f"[DefaultStrategy] Starting move generation", OUTPUT_DEBUG)
+        self.game.katrain.log("[DefaultStrategy] Starting move generation", OUTPUT_DEBUG)
         self.wait_for_analysis()
-        
+
         candidate_moves = self.cn.candidate_moves
         self.game.katrain.log(f"[DefaultStrategy] Analysis found {len(candidate_moves)} candidate moves", OUTPUT_DEBUG)
-        
+
         if not candidate_moves:
-            self.game.katrain.log(f"[DefaultStrategy] No candidate moves found, will play pass", OUTPUT_DEBUG)
+            self.game.katrain.log("[DefaultStrategy] No candidate moves found, will play pass", OUTPUT_DEBUG)
             top_cand = Move(is_pass=True, player=self.cn.next_player)
         else:
             top_move_data = candidate_moves[0]
             top_cand = Move.from_gtp(top_move_data["move"], player=self.cn.next_player)
-            self.game.katrain.log(f"[DefaultStrategy] Top move: {top_cand.gtp()} with stats: {top_move_data}", OUTPUT_DEBUG)
-        
+            self.game.katrain.log(
+                f"[DefaultStrategy] Top move: {top_cand.gtp()} with stats: {top_move_data}", OUTPUT_DEBUG
+            )
+
         ai_thoughts = f"Default strategy found {len(candidate_moves)} moves returned from the engine and chose {top_cand.gtp()} as top move"
         self.game.katrain.log(f"[DefaultStrategy] Final decision: {top_cand.gtp()}", OUTPUT_DEBUG)
-        
+
         return top_cand, ai_thoughts
+
 
 @register_strategy(AI_HANDICAP)
 class HandicapStrategy(AIStrategy):
     """Handicap strategy - uses playoutDoublingAdvantage to analyze the position"""
-    
+
     def generate_move(self) -> Tuple[Move, str]:
-        self.game.katrain.log(f"[HandicapStrategy] Starting move generation", OUTPUT_DEBUG)
-        
+        self.game.katrain.log("[HandicapStrategy] Starting move generation", OUTPUT_DEBUG)
+
         # Calculate PDA (Playout Doubling Advantage)
         pda = self.settings["pda"]
         self.game.katrain.log(f"[HandicapStrategy] Initial PDA from settings: {pda}", OUTPUT_DEBUG)
-        
+
         if self.settings["automatic"]:
             n_handicaps = len(self.game.root.get_list_property("AB", []))
             MOVE_VALUE = 14  # could be rules dependent
             b_stones_advantage = max(n_handicaps - 1, 0) - (self.cn.komi - MOVE_VALUE / 2) / MOVE_VALUE
             pda = min(3, max(-3, -b_stones_advantage * (3 / 8)))  # max PDA at 8 stone adv, normal 9 stone game is 8.46
-            
-            self.game.katrain.log(f"[HandicapStrategy] Automatic PDA calculation:", OUTPUT_DEBUG)
+
+            self.game.katrain.log("[HandicapStrategy] Automatic PDA calculation:", OUTPUT_DEBUG)
             self.game.katrain.log(f"[HandicapStrategy] - Handicap stones: {n_handicaps}", OUTPUT_DEBUG)
             self.game.katrain.log(f"[HandicapStrategy] - Komi: {self.cn.komi}", OUTPUT_DEBUG)
             self.game.katrain.log(f"[HandicapStrategy] - Stone advantage: {b_stones_advantage}", OUTPUT_DEBUG)
             self.game.katrain.log(f"[HandicapStrategy] - Calculated PDA: {pda}", OUTPUT_DEBUG)
-        
+
         # Request additional analysis with PDA
         self.game.katrain.log(f"[HandicapStrategy] Requesting analysis with PDA={pda}", OUTPUT_DEBUG)
         handicap_analysis = self.request_analysis(
             {"playoutDoublingAdvantage": pda, "playoutDoublingAdvantagePla": "BLACK"}
         )
-        
+
         if not handicap_analysis:
-            self.game.katrain.log("[HandicapStrategy] Error getting handicap-based move, falling back to DefaultStrategy", OUTPUT_ERROR)
+            self.game.katrain.log(
+                "[HandicapStrategy] Error getting handicap-based move, falling back to DefaultStrategy", OUTPUT_ERROR
+            )
             return DefaultStrategy(self.game, self.settings).generate_move()
-        
+
         self.wait_for_analysis()
-        
+
         candidate_moves = handicap_analysis["moveInfos"]
-        self.game.katrain.log(f"[HandicapStrategy] Analysis returned {len(candidate_moves)} candidate moves", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[HandicapStrategy] Analysis returned {len(candidate_moves)} candidate moves", OUTPUT_DEBUG
+        )
+
         # Get top candidate move
         top_move_data = candidate_moves[0]
         top_cand = Move.from_gtp(top_move_data["move"], player=self.cn.next_player)
-        
+
         # Log details about the top move
         self.game.katrain.log(f"[HandicapStrategy] Top move: {top_cand.gtp()}", OUTPUT_DEBUG)
-        self.game.katrain.log(f"[HandicapStrategy] Score lead: {handicap_analysis['rootInfo']['scoreLead']}", OUTPUT_DEBUG)
+        self.game.katrain.log(
+            f"[HandicapStrategy] Score lead: {handicap_analysis['rootInfo']['scoreLead']}", OUTPUT_DEBUG
+        )
         self.game.katrain.log(f"[HandicapStrategy] Win rate: {handicap_analysis['rootInfo']['winrate']}", OUTPUT_DEBUG)
-        
+
         ai_thoughts = f"Handicap strategy found {len(candidate_moves)} moves returned from the engine and chose {top_cand.gtp()} as top move. PDA based score {self.cn.format_score(handicap_analysis['rootInfo']['scoreLead'])} and win rate {self.cn.format_winrate(handicap_analysis['rootInfo']['winrate'])}"
-        
+
         self.game.katrain.log(f"[HandicapStrategy] Final decision: {top_cand.gtp()}", OUTPUT_DEBUG)
         return top_cand, ai_thoughts
+
 
 @register_strategy(AI_ANTIMIRROR)
 class AntimirrorStrategy(AIStrategy):
     """Antimirror strategy - uses antiMirror to analyze the position"""
-    
+
     def generate_move(self) -> Tuple[Move, str]:
-        self.game.katrain.log(f"[AntimirrorStrategy] Starting move generation", OUTPUT_DEBUG)
-        
+        self.game.katrain.log("[AntimirrorStrategy] Starting move generation", OUTPUT_DEBUG)
+
         # Request analysis with antimirror option
-        self.game.katrain.log(f"[AntimirrorStrategy] Requesting analysis with antiMirror=True", OUTPUT_DEBUG)
+        self.game.katrain.log("[AntimirrorStrategy] Requesting analysis with antiMirror=True", OUTPUT_DEBUG)
         antimirror_analysis = self.request_analysis({"antiMirror": True})
-        
+
         if not antimirror_analysis:
-            self.game.katrain.log("[AntimirrorStrategy] Error getting antimirror move, falling back to DefaultStrategy", OUTPUT_ERROR)
+            self.game.katrain.log(
+                "[AntimirrorStrategy] Error getting antimirror move, falling back to DefaultStrategy", OUTPUT_ERROR
+            )
             return DefaultStrategy(self.game, self.settings).generate_move()
-        
+
         self.wait_for_analysis()
-        
+
         candidate_moves = antimirror_analysis["moveInfos"]
-        self.game.katrain.log(f"[AntimirrorStrategy] Analysis returned {len(candidate_moves)} candidate moves", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[AntimirrorStrategy] Analysis returned {len(candidate_moves)} candidate moves", OUTPUT_DEBUG
+        )
+
         # Get top candidate move
         top_move_data = candidate_moves[0]
         top_cand = Move.from_gtp(top_move_data["move"], player=self.cn.next_player)
-        
+
         # Log details about the top move
         self.game.katrain.log(f"[AntimirrorStrategy] Top move: {top_cand.gtp()}", OUTPUT_DEBUG)
-        self.game.katrain.log(f"[AntimirrorStrategy] Score lead: {antimirror_analysis['rootInfo']['scoreLead']}", OUTPUT_DEBUG)
-        self.game.katrain.log(f"[AntimirrorStrategy] Win rate: {antimirror_analysis['rootInfo']['winrate']}", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[AntimirrorStrategy] Score lead: {antimirror_analysis['rootInfo']['scoreLead']}", OUTPUT_DEBUG
+        )
+        self.game.katrain.log(
+            f"[AntimirrorStrategy] Win rate: {antimirror_analysis['rootInfo']['winrate']}", OUTPUT_DEBUG
+        )
+
         # Log the top 3 moves for comparison
         for i, move_data in enumerate(candidate_moves[:3]):
             move = Move.from_gtp(move_data["move"], player=self.cn.next_player)
-            self.game.katrain.log(f"[AntimirrorStrategy] Move #{i+1}: {move.gtp()} - visits: {move_data.get('visits', 'N/A')}, points lost: {move_data.get('pointsLost', 'N/A')}", OUTPUT_DEBUG)
-        
+            self.game.katrain.log(
+                f"[AntimirrorStrategy] Move #{i + 1}: {move.gtp()} - visits: {move_data.get('visits', 'N/A')}, points lost: {move_data.get('pointsLost', 'N/A')}",
+                OUTPUT_DEBUG,
+            )
+
         ai_thoughts = f"AntiMirror strategy found {len(candidate_moves)} moves returned from the engine and chose {top_cand.gtp()} as top move. antiMirror based score {self.cn.format_score(antimirror_analysis['rootInfo']['scoreLead'])} and win rate {self.cn.format_winrate(antimirror_analysis['rootInfo']['winrate'])}"
-        
+
         self.game.katrain.log(f"[AntimirrorStrategy] Final decision: {top_cand.gtp()}", OUTPUT_DEBUG)
         return top_cand, ai_thoughts
+
 
 @register_strategy(AI_JIGO)
 class JigoStrategy(AIStrategy):
     """Jigo strategy - aims for a specific score difference"""
-    
+
     def generate_move(self) -> Tuple[Move, str]:
-        self.game.katrain.log(f"[JigoStrategy] Starting move generation", OUTPUT_DEBUG)
+        self.game.katrain.log("[JigoStrategy] Starting move generation", OUTPUT_DEBUG)
         self.wait_for_analysis()
-        
+
         candidate_moves = self.cn.candidate_moves
         self.game.katrain.log(f"[JigoStrategy] Analysis found {len(candidate_moves)} candidate moves", OUTPUT_DEBUG)
-        
+
         if not candidate_moves:
-            self.game.katrain.log(f"[JigoStrategy] No candidate moves found, will play pass", OUTPUT_DEBUG)
+            self.game.katrain.log("[JigoStrategy] No candidate moves found, will play pass", OUTPUT_DEBUG)
             return Move(is_pass=True, player=self.cn.next_player), "No candidate moves found, passing"
-        
+
         # Get top engine move for reference
         top_cand = Move.from_gtp(candidate_moves[0]["move"], player=self.cn.next_player)
         self.game.katrain.log(f"[JigoStrategy] Top engine move would be: {top_cand.gtp()}", OUTPUT_DEBUG)
-        
+
         # Calculate player sign (1 for black, -1 for white)
         sign = self.cn.player_sign(self.cn.next_player)
         self.game.katrain.log(f"[JigoStrategy] Player sign: {sign}", OUTPUT_DEBUG)
-        
+
         # Get target score from settings
         target_score = self.settings["target_score"]
         self.game.katrain.log(f"[JigoStrategy] Target score: {target_score}", OUTPUT_DEBUG)
-        
+
         # Log score leads before selecting jigo move
         self.game.katrain.log("[JigoStrategy] Candidate move score leads:", OUTPUT_DEBUG)
         for i, move_data in enumerate(candidate_moves[:5]):
             move = Move.from_gtp(move_data["move"], player=self.cn.next_player)
             score_diff = abs(sign * move_data["scoreLead"] - target_score)
-            self.game.katrain.log(f"[JigoStrategy] - {move.gtp()}: scoreLead={move_data['scoreLead']}, diff from target={score_diff}", OUTPUT_DEBUG)
-        
+            self.game.katrain.log(
+                f"[JigoStrategy] - {move.gtp()}: scoreLead={move_data['scoreLead']}, diff from target={score_diff}",
+                OUTPUT_DEBUG,
+            )
+
         # Find the move that gives a score closest to the target
-        jigo_move = min(
-            candidate_moves, 
-            key=lambda move: abs(sign * move["scoreLead"] - target_score)
-        )
-        
+        jigo_move = min(candidate_moves, key=lambda move: abs(sign * move["scoreLead"] - target_score))
+
         aimove = Move.from_gtp(jigo_move["move"], player=self.cn.next_player)
         jigo_score_diff = abs(sign * jigo_move["scoreLead"] - target_score)
-        
+
         self.game.katrain.log(f"[JigoStrategy] Selected move: {aimove.gtp()}", OUTPUT_DEBUG)
         self.game.katrain.log(f"[JigoStrategy] Selected move score lead: {jigo_move['scoreLead']}", OUTPUT_DEBUG)
         self.game.katrain.log(f"[JigoStrategy] Distance from target: {jigo_score_diff}", OUTPUT_DEBUG)
-        
+
         ai_thoughts = f"Jigo strategy found {len(candidate_moves)} candidate moves (best {top_cand.gtp()}) and chose {aimove.gtp()} as closest to 0.5 point win"
-        
+
         self.game.katrain.log(f"[JigoStrategy] Final decision: {aimove.gtp()}", OUTPUT_DEBUG)
         return aimove, ai_thoughts
+
 
 @register_strategy(AI_SCORELOSS)
 class ScoreLossStrategy(AIStrategy):
     """ScoreLoss strategy - weights moves based on point loss"""
-    
+
     def generate_move(self) -> Tuple[Move, str]:
-        self.game.katrain.log(f"[ScoreLossStrategy] Starting move generation", OUTPUT_DEBUG)
+        self.game.katrain.log("[ScoreLossStrategy] Starting move generation", OUTPUT_DEBUG)
         self.wait_for_analysis()
-        
+
         candidate_moves = self.cn.candidate_moves
-        self.game.katrain.log(f"[ScoreLossStrategy] Analysis found {len(candidate_moves)} candidate moves", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[ScoreLossStrategy] Analysis found {len(candidate_moves)} candidate moves", OUTPUT_DEBUG
+        )
+
         if not candidate_moves:
-            self.game.katrain.log(f"[ScoreLossStrategy] No candidate moves found, will play pass", OUTPUT_DEBUG)
+            self.game.katrain.log("[ScoreLossStrategy] No candidate moves found, will play pass", OUTPUT_DEBUG)
             return Move(is_pass=True, player=self.cn.next_player), "No candidate moves found, passing"
-        
+
         top_cand = Move.from_gtp(candidate_moves[0]["move"], player=self.cn.next_player)
         self.game.katrain.log(f"[ScoreLossStrategy] Top engine move would be: {top_cand.gtp()}", OUTPUT_DEBUG)
-        
+
         # Check if top move is pass
         if top_cand.is_pass:
-            self.game.katrain.log(f"[ScoreLossStrategy] Top move is pass, so passing regardless of strategy", OUTPUT_DEBUG)
+            self.game.katrain.log(
+                "[ScoreLossStrategy] Top move is pass, so passing regardless of strategy", OUTPUT_DEBUG
+            )
             return top_cand, "Top move is pass, so passing regardless of strategy."
-        
+
         # Get strength parameter
         c = self.settings["strength"]
         self.game.katrain.log(f"[ScoreLossStrategy] Strength parameter: {c}", OUTPUT_DEBUG)
-        
+
         # Calculate weights for moves based on point loss
-        self.game.katrain.log(f"[ScoreLossStrategy] Calculating weights for candidate moves", OUTPUT_DEBUG)
-        
+        self.game.katrain.log("[ScoreLossStrategy] Calculating weights for candidate moves", OUTPUT_DEBUG)
+
         moves = []
         for i, d in enumerate(candidate_moves):
             move = Move.from_gtp(d["move"], player=self.cn.next_player)
             points_lost = d["pointsLost"]
             weight = math.exp(min(200, -c * max(0, points_lost)))
-            
-            self.game.katrain.log(f"[ScoreLossStrategy] Move {i+1}: {move.gtp()} - Points lost: {points_lost:.2f}, Weight: {weight:.6f}", OUTPUT_DEBUG)
+
+            self.game.katrain.log(
+                f"[ScoreLossStrategy] Move {i + 1}: {move.gtp()} - Points lost: {points_lost:.2f}, Weight: {weight:.6f}",
+                OUTPUT_DEBUG,
+            )
             moves.append((points_lost, weight, move))
-        
+
         # Select move based on weights
-        self.game.katrain.log(f"[ScoreLossStrategy] Selecting move with weighted selection", OUTPUT_DEBUG)
+        self.game.katrain.log("[ScoreLossStrategy] Selecting move with weighted selection", OUTPUT_DEBUG)
         topmove = weighted_selection_without_replacement(moves, 1)[0]
         aimove = topmove[2]
-        
+
         self.game.katrain.log(f"[ScoreLossStrategy] Selected move: {aimove.gtp()}", OUTPUT_DEBUG)
         self.game.katrain.log(f"[ScoreLossStrategy] Selected move points lost: {topmove[0]:.2f}", OUTPUT_DEBUG)
         self.game.katrain.log(f"[ScoreLossStrategy] Selected move weight: {topmove[1]:.6f}", OUTPUT_DEBUG)
-        
+
         ai_thoughts = f"ScoreLoss strategy found {len(candidate_moves)} candidate moves (best {top_cand.gtp()}) and chose {aimove.gtp()} (weight {topmove[1]:.3f}, point loss {topmove[0]:.1f}) based on score weights."
-        
+
         self.game.katrain.log(f"[ScoreLossStrategy] Final decision: {aimove.gtp()}", OUTPUT_DEBUG)
         return aimove, ai_thoughts
 
+
 class OwnershipBaseStrategy(AIStrategy):
     """Base class for ownership-based strategies"""
-    
+
     def settledness(self, d, player_sign, player):
         """Calculate settledness for Simple Ownership strategy"""
         ownership_sum = sum([abs(o) for o in d["ownership"] if player_sign * o > 0])
-        self.game.katrain.log(f"[{self.strategy_name}] Calculating settledness for {player}, sign={player_sign}: {ownership_sum:.2f}", OUTPUT_DEBUG)
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Calculating settledness for {player}, sign={player_sign}: {ownership_sum:.2f}",
+            OUTPUT_DEBUG,
+        )
         return ownership_sum
-    
+
     def is_attachment(self, move):
         """Check if a move is an attachment"""
         if move.is_pass:
             return False
-            
+
         stones_with_player = {(*s.coords, s.player) for s in self.game.stones}
-        
+
         attach_opponent_stones = sum(
             (move.coords[0] + dx, move.coords[1] + dy, self.cn.player) in stones_with_player
             for dx in [-1, 0, 1]
             for dy in [-1, 0, 1]
             if abs(dx) + abs(dy) == 1
         )
-        
+
         nearby_own_stones = sum(
             (move.coords[0] + dx, move.coords[1] + dy, self.cn.next_player) in stones_with_player
             for dx in [-2, 0, 1, 2]
             for dy in [-2 - 1, 0, 1, 2]
             if abs(dx) + abs(dy) <= 2  # allows clamps/jumps
         )
-        
+
         is_attach = attach_opponent_stones >= 1 and nearby_own_stones == 0
-        self.game.katrain.log(f"[{self.strategy_name}] Is move {move.gtp()} an attachment? {is_attach} (opponent stones: {attach_opponent_stones}, own stones: {nearby_own_stones})", OUTPUT_DEBUG)
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Is move {move.gtp()} an attachment? {is_attach} (opponent stones: {attach_opponent_stones}, own stones: {nearby_own_stones})",
+            OUTPUT_DEBUG,
+        )
         return is_attach
-    
+
     def is_tenuki(self, move):
         """Check if a move is a tenuki (far from previous moves)"""
         if move.is_pass:
             return False
-            
+
         result = not any(
             not node
             or not node.move
@@ -543,770 +638,921 @@ class OwnershipBaseStrategy(AIStrategy):
             or max(abs(last_c - cand_c) for last_c, cand_c in zip(node.move.coords, move.coords)) < 5
             for node in [self.cn, self.cn.parent]
         )
-        
+
         distances = []
         for node in [self.cn, self.cn.parent]:
             if node and node.move and not node.move.is_pass:
                 dist = max(abs(last_c - cand_c) for last_c, cand_c in zip(node.move.coords, move.coords))
                 distances.append(dist)
-                
+
         if distances:
-            self.game.katrain.log(f"[{self.strategy_name}] Is move {move.gtp()} a tenuki? {result} (distances: {distances})", OUTPUT_DEBUG)
+            self.game.katrain.log(
+                f"[{self.strategy_name}] Is move {move.gtp()} a tenuki? {result} (distances: {distances})", OUTPUT_DEBUG
+            )
         else:
-            self.game.katrain.log(f"[{self.strategy_name}] Is move {move.gtp()} a tenuki? {result} (no valid previous moves)", OUTPUT_DEBUG)
-            
+            self.game.katrain.log(
+                f"[{self.strategy_name}] Is move {move.gtp()} a tenuki? {result} (no valid previous moves)",
+                OUTPUT_DEBUG,
+            )
+
         return result
-    
+
     def get_moves_with_settledness(self):
         """Get moves with ownership and settledness information"""
         self.game.katrain.log(f"[{self.strategy_name}] Getting moves with settledness information", OUTPUT_DEBUG)
-        
+
         next_player_sign = self.cn.player_sign(self.cn.next_player)
         candidate_moves = self.cn.candidate_moves
-        
+
         self.game.katrain.log(f"[{self.strategy_name}] Processing {len(candidate_moves)} candidate moves", OUTPUT_DEBUG)
-        self.game.katrain.log(f"[{self.strategy_name}] Settings: max_points_lost={self.settings['max_points_lost']}, min_visits={self.settings.get('min_visits', 1)}", OUTPUT_DEBUG)
-        self.game.katrain.log(f"[{self.strategy_name}] Penalties: attach={self.settings['attach_penalty']}, tenuki={self.settings['tenuki_penalty']}", OUTPUT_DEBUG)
-        self.game.katrain.log(f"[{self.strategy_name}] Weights: settled={self.settings['settled_weight']}, opponent_fac={self.settings['opponent_fac']}", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Settings: max_points_lost={self.settings['max_points_lost']}, min_visits={self.settings.get('min_visits', 1)}",
+            OUTPUT_DEBUG,
+        )
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Penalties: attach={self.settings['attach_penalty']}, tenuki={self.settings['tenuki_penalty']}",
+            OUTPUT_DEBUG,
+        )
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Weights: settled={self.settings['settled_weight']}, opponent_fac={self.settings['opponent_fac']}",
+            OUTPUT_DEBUG,
+        )
+
         moves_data = []
         for d in candidate_moves:
             # Check basic filtering conditions
             if "pointsLost" not in d:
-                self.game.katrain.log(f"[{self.strategy_name}] Move {d['move']} has no pointsLost, skipping", OUTPUT_DEBUG)
+                self.game.katrain.log(
+                    f"[{self.strategy_name}] Move {d['move']} has no pointsLost, skipping", OUTPUT_DEBUG
+                )
                 continue
-                
+
             if d["pointsLost"] >= self.settings["max_points_lost"]:
-                self.game.katrain.log(f"[{self.strategy_name}] Move {d['move']} has pointsLost={d['pointsLost']}, which exceeds max_points_lost={self.settings['max_points_lost']}, skipping", OUTPUT_DEBUG)
+                self.game.katrain.log(
+                    f"[{self.strategy_name}] Move {d['move']} has pointsLost={d['pointsLost']}, which exceeds max_points_lost={self.settings['max_points_lost']}, skipping",
+                    OUTPUT_DEBUG,
+                )
                 continue
-                
+
             if "ownership" not in d:
-                self.game.katrain.log(f"[{self.strategy_name}] Move {d['move']} has no ownership data, skipping", OUTPUT_DEBUG)
+                self.game.katrain.log(
+                    f"[{self.strategy_name}] Move {d['move']} has no ownership data, skipping", OUTPUT_DEBUG
+                )
                 continue
-                
+
             if not (d["order"] <= 1 or d["visits"] >= self.settings.get("min_visits", 1)):
-                self.game.katrain.log(f"[{self.strategy_name}] Move {d['move']} has order={d['order']} and visits={d.get('visits', 'N/A')}, doesn't meet criteria, skipping", OUTPUT_DEBUG)
+                self.game.katrain.log(
+                    f"[{self.strategy_name}] Move {d['move']} has order={d['order']} and visits={d.get('visits', 'N/A')}, doesn't meet criteria, skipping",
+                    OUTPUT_DEBUG,
+                )
                 continue
-            
+
             move = Move.from_gtp(d["move"], player=self.cn.next_player)
             if move.is_pass and d["pointsLost"] > 0.75:
-                self.game.katrain.log(f"[{self.strategy_name}] Move {move.gtp()} is pass with high point loss ({d['pointsLost']}), skipping", OUTPUT_DEBUG)
+                self.game.katrain.log(
+                    f"[{self.strategy_name}] Move {move.gtp()} is pass with high point loss ({d['pointsLost']}), skipping",
+                    OUTPUT_DEBUG,
+                )
                 continue
-            
+
             # Calculate metrics
             own_settledness = self.settledness(d, next_player_sign, self.cn.next_player)
             opp_settledness = self.settledness(d, -next_player_sign, self.cn.player)
             is_attach = self.is_attachment(move)
             is_tenuki = self.is_tenuki(move)
-            
+
             # Calculate total score for sorting
-            score = (d["pointsLost"] 
-                    + self.settings["attach_penalty"] * is_attach 
-                    + self.settings["tenuki_penalty"] * is_tenuki
-                    - self.settings["settled_weight"] * (own_settledness + self.settings["opponent_fac"] * opp_settledness))
-            
-            self.game.katrain.log(f"[{self.strategy_name}] Move {move.gtp()}: points_lost={d['pointsLost']:.2f}, own_settled={own_settledness:.2f}, opp_settled={opp_settledness:.2f}, attach={is_attach}, tenuki={is_tenuki}, score={score:.2f}", OUTPUT_DEBUG)
-            
-            moves_data.append((
-                move,
-                own_settledness,
-                opp_settledness,
-                is_attach,
-                is_tenuki,
-                d,
-                score  # Store the score for debugging
-            ))
-        
+            score = (
+                d["pointsLost"]
+                + self.settings["attach_penalty"] * is_attach
+                + self.settings["tenuki_penalty"] * is_tenuki
+                - self.settings["settled_weight"] * (own_settledness + self.settings["opponent_fac"] * opp_settledness)
+            )
+
+            self.game.katrain.log(
+                f"[{self.strategy_name}] Move {move.gtp()}: points_lost={d['pointsLost']:.2f}, own_settled={own_settledness:.2f}, opp_settled={opp_settledness:.2f}, attach={is_attach}, tenuki={is_tenuki}, score={score:.2f}",
+                OUTPUT_DEBUG,
+            )
+
+            moves_data.append(
+                (
+                    move,
+                    own_settledness,
+                    opp_settledness,
+                    is_attach,
+                    is_tenuki,
+                    d,
+                    score,  # Store the score for debugging
+                )
+            )
+
         # Sort moves by score
         sorted_moves = sorted(
             moves_data,
-            key=lambda t: t[6]  # Sort by the precalculated score
+            key=lambda t: t[6],  # Sort by the precalculated score
         )
-        
-        self.game.katrain.log(f"[{self.strategy_name}] Found {len(sorted_moves)} valid moves with settledness data", OUTPUT_DEBUG)
+
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Found {len(sorted_moves)} valid moves with settledness data", OUTPUT_DEBUG
+        )
         if sorted_moves:
-            self.game.katrain.log(f"[{self.strategy_name}] Top move after sorting: {sorted_moves[0][0].gtp()} with score {sorted_moves[0][6]:.2f}", OUTPUT_DEBUG)
-        
+            self.game.katrain.log(
+                f"[{self.strategy_name}] Top move after sorting: {sorted_moves[0][0].gtp()} with score {sorted_moves[0][6]:.2f}",
+                OUTPUT_DEBUG,
+            )
+
         # Return all data except the score which was just for debugging
-        return [(move, own_settled, opp_settled, is_attach, is_tenuki, d) for move, own_settled, opp_settled, is_attach, is_tenuki, d, _ in sorted_moves]
+        return [
+            (move, own_settled, opp_settled, is_attach, is_tenuki, d)
+            for move, own_settled, opp_settled, is_attach, is_tenuki, d, _ in sorted_moves
+        ]
+
 
 @register_strategy(AI_SIMPLE_OWNERSHIP)
 class SimpleOwnershipStrategy(OwnershipBaseStrategy):
     """Simple Ownership strategy - weights moves based on territory control"""
-    
+
     def generate_move(self) -> Tuple[Move, str]:
-        self.game.katrain.log(f"[SimpleOwnershipStrategy] Starting move generation", OUTPUT_DEBUG)
+        self.game.katrain.log("[SimpleOwnershipStrategy] Starting move generation", OUTPUT_DEBUG)
         self.wait_for_analysis()
-        
+
         candidate_moves = self.cn.candidate_moves
-        self.game.katrain.log(f"[SimpleOwnershipStrategy] Analysis found {len(candidate_moves)} candidate moves", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[SimpleOwnershipStrategy] Analysis found {len(candidate_moves)} candidate moves", OUTPUT_DEBUG
+        )
+
         if not candidate_moves:
-            self.game.katrain.log(f"[SimpleOwnershipStrategy] No candidate moves found, will play pass", OUTPUT_DEBUG)
+            self.game.katrain.log("[SimpleOwnershipStrategy] No candidate moves found, will play pass", OUTPUT_DEBUG)
             return Move(is_pass=True, player=self.cn.next_player), "No candidate moves found, passing"
-        
+
         top_cand = Move.from_gtp(candidate_moves[0]["move"], player=self.cn.next_player)
         self.game.katrain.log(f"[SimpleOwnershipStrategy] Top engine move would be: {top_cand.gtp()}", OUTPUT_DEBUG)
-        
+
         # Check if top move is pass
         if top_cand.is_pass:
-            self.game.katrain.log(f"[SimpleOwnershipStrategy] Top move is pass, so passing regardless of strategy", OUTPUT_DEBUG)
+            self.game.katrain.log(
+                "[SimpleOwnershipStrategy] Top move is pass, so passing regardless of strategy", OUTPUT_DEBUG
+            )
             return top_cand, "Top move is pass, so passing regardless of strategy."
-        
+
         # Get moves sorted by settledness criteria
-        self.game.katrain.log(f"[SimpleOwnershipStrategy] Getting moves with settledness info", OUTPUT_DEBUG)
+        self.game.katrain.log("[SimpleOwnershipStrategy] Getting moves with settledness info", OUTPUT_DEBUG)
         moves_with_settledness = self.get_moves_with_settledness()
-        
+
         if moves_with_settledness:
-            self.game.katrain.log(f"[SimpleOwnershipStrategy] Found {len(moves_with_settledness)} moves with settledness info", OUTPUT_DEBUG)
-            
+            self.game.katrain.log(
+                f"[SimpleOwnershipStrategy] Found {len(moves_with_settledness)} moves with settledness info",
+                OUTPUT_DEBUG,
+            )
+
             # Log top 5 candidates in detail
-            self.game.katrain.log(f"[SimpleOwnershipStrategy] Top 5 candidates:", OUTPUT_DEBUG)
+            self.game.katrain.log("[SimpleOwnershipStrategy] Top 5 candidates:", OUTPUT_DEBUG)
             for i, (move, settled, oppsettled, isattach, istenuki, d) in enumerate(moves_with_settledness[:5]):
-                self.game.katrain.log(f"[SimpleOwnershipStrategy] #{i+1}: {move.gtp()} - pt_lost: {d['pointsLost']:.1f}, visits: {d.get('visits', 'N/A')}, settledness: {settled:.1f}, opp_settled: {oppsettled:.1f}, attach: {isattach}, tenuki: {istenuki}", OUTPUT_DEBUG)
-            
+                self.game.katrain.log(
+                    f"[SimpleOwnershipStrategy] #{i + 1}: {move.gtp()} - pt_lost: {d['pointsLost']:.1f}, visits: {d.get('visits', 'N/A')}, settledness: {settled:.1f}, opp_settled: {oppsettled:.1f}, attach: {isattach}, tenuki: {istenuki}",
+                    OUTPUT_DEBUG,
+                )
+
             # Format candidate moves for ai_thoughts
             cands = [
                 f"{move.gtp()} ({d['pointsLost']:.1f} pt lost, {d.get('visits', 'N/A')} visits, {settled:.1f} settledness, {oppsettled:.1f} opponent settledness{', attachment' if isattach else ''}{', tenuki' if istenuki else ''})"
                 for move, settled, oppsettled, isattach, istenuki, d in moves_with_settledness[:5]
             ]
-            
+
             ai_thoughts = f"{AI_SIMPLE_OWNERSHIP} strategy. Top 5 Candidates {', '.join(cands)} "
             aimove = moves_with_settledness[0][0]
-            
+
             self.game.katrain.log(f"[SimpleOwnershipStrategy] Selected move: {aimove.gtp()}", OUTPUT_DEBUG)
         else:
             error_msg = "No moves found - are you using an older KataGo with no per-move ownership info?"
             self.game.katrain.log(f"[SimpleOwnershipStrategy] Error: {error_msg}", OUTPUT_ERROR)
             raise Exception(error_msg)
-        
+
         self.game.katrain.log(f"[SimpleOwnershipStrategy] Final decision: {aimove.gtp()}", OUTPUT_DEBUG)
         return aimove, ai_thoughts
+
 
 @register_strategy(AI_SETTLE_STONES)
 class SettleStonesStrategy(OwnershipBaseStrategy):
     """Settle Stones strategy - focuses on settled stones"""
-    
+
     def settledness(self, d, player_sign, player):
         """Calculate settledness for Settle Stones strategy"""
         board_size_x, board_size_y = self.game.board_size
         ownership_grid = var_to_grid(d["ownership"], (board_size_x, board_size_y))
-        
+
         # Sum the absolute ownership values of existing stones
-        stone_ownership_values = [abs(ownership_grid[s.coords[0]][s.coords[1]]) for s in self.game.stones if s.player == player]
+        stone_ownership_values = [
+            abs(ownership_grid[s.coords[0]][s.coords[1]]) for s in self.game.stones if s.player == player
+        ]
         total_settledness = sum(stone_ownership_values)
-        
-        self.game.katrain.log(f"[SettleStonesStrategy] Calculating settledness for {player}, sign={player_sign}", OUTPUT_DEBUG)
-        self.game.katrain.log(f"[SettleStonesStrategy] Number of stones considered: {len(stone_ownership_values)}", OUTPUT_DEBUG)
+
+        self.game.katrain.log(
+            f"[SettleStonesStrategy] Calculating settledness for {player}, sign={player_sign}", OUTPUT_DEBUG
+        )
+        self.game.katrain.log(
+            f"[SettleStonesStrategy] Number of stones considered: {len(stone_ownership_values)}", OUTPUT_DEBUG
+        )
         self.game.katrain.log(f"[SettleStonesStrategy] Total settledness: {total_settledness:.2f}", OUTPUT_DEBUG)
-        
+
         if stone_ownership_values:
-            self.game.katrain.log(f"[SettleStonesStrategy] Min stone ownership: {min(stone_ownership_values):.2f}", OUTPUT_DEBUG)
-            self.game.katrain.log(f"[SettleStonesStrategy] Max stone ownership: {max(stone_ownership_values):.2f}", OUTPUT_DEBUG)
-            self.game.katrain.log(f"[SettleStonesStrategy] Avg stone ownership: {total_settledness / len(stone_ownership_values):.2f}", OUTPUT_DEBUG)
-        
+            self.game.katrain.log(
+                f"[SettleStonesStrategy] Min stone ownership: {min(stone_ownership_values):.2f}", OUTPUT_DEBUG
+            )
+            self.game.katrain.log(
+                f"[SettleStonesStrategy] Max stone ownership: {max(stone_ownership_values):.2f}", OUTPUT_DEBUG
+            )
+            self.game.katrain.log(
+                f"[SettleStonesStrategy] Avg stone ownership: {total_settledness / len(stone_ownership_values):.2f}",
+                OUTPUT_DEBUG,
+            )
+
         return total_settledness
-    
+
     def generate_move(self) -> Tuple[Move, str]:
-        self.game.katrain.log(f"[SettleStonesStrategy] Starting move generation", OUTPUT_DEBUG)
+        self.game.katrain.log("[SettleStonesStrategy] Starting move generation", OUTPUT_DEBUG)
         self.wait_for_analysis()
-        
+
         candidate_moves = self.cn.candidate_moves
-        self.game.katrain.log(f"[SettleStonesStrategy] Analysis found {len(candidate_moves)} candidate moves", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[SettleStonesStrategy] Analysis found {len(candidate_moves)} candidate moves", OUTPUT_DEBUG
+        )
+
         if not candidate_moves:
-            self.game.katrain.log(f"[SettleStonesStrategy] No candidate moves found, will play pass", OUTPUT_DEBUG)
+            self.game.katrain.log("[SettleStonesStrategy] No candidate moves found, will play pass", OUTPUT_DEBUG)
             return Move(is_pass=True, player=self.cn.next_player), "No candidate moves found, passing"
-        
+
         top_cand = Move.from_gtp(candidate_moves[0]["move"], player=self.cn.next_player)
         self.game.katrain.log(f"[SettleStonesStrategy] Top engine move would be: {top_cand.gtp()}", OUTPUT_DEBUG)
-        
+
         # Check if top move is pass
         if top_cand.is_pass:
-            self.game.katrain.log(f"[SettleStonesStrategy] Top move is pass, so passing regardless of strategy", OUTPUT_DEBUG)
+            self.game.katrain.log(
+                "[SettleStonesStrategy] Top move is pass, so passing regardless of strategy", OUTPUT_DEBUG
+            )
             return top_cand, "Top move is pass, so passing regardless of strategy."
-        
+
         # Log the number of stones on the board
         black_stones = sum(1 for s in self.game.stones if s.player == "B")
         white_stones = sum(1 for s in self.game.stones if s.player == "W")
-        self.game.katrain.log(f"[SettleStonesStrategy] Stones on board: B={black_stones}, W={white_stones}", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[SettleStonesStrategy] Stones on board: B={black_stones}, W={white_stones}", OUTPUT_DEBUG
+        )
+
         # Get moves sorted by settledness criteria
-        self.game.katrain.log(f"[SettleStonesStrategy] Getting moves with settledness info", OUTPUT_DEBUG)
+        self.game.katrain.log("[SettleStonesStrategy] Getting moves with settledness info", OUTPUT_DEBUG)
         moves_with_settledness = self.get_moves_with_settledness()
-        
+
         if moves_with_settledness:
-            self.game.katrain.log(f"[SettleStonesStrategy] Found {len(moves_with_settledness)} moves with settledness info", OUTPUT_DEBUG)
-            
+            self.game.katrain.log(
+                f"[SettleStonesStrategy] Found {len(moves_with_settledness)} moves with settledness info", OUTPUT_DEBUG
+            )
+
             # Log top 5 candidates in detail
-            self.game.katrain.log(f"[SettleStonesStrategy] Top 5 candidates:", OUTPUT_DEBUG)
+            self.game.katrain.log("[SettleStonesStrategy] Top 5 candidates:", OUTPUT_DEBUG)
             for i, (move, settled, oppsettled, isattach, istenuki, d) in enumerate(moves_with_settledness[:5]):
-                self.game.katrain.log(f"[SettleStonesStrategy] #{i+1}: {move.gtp()} - pt_lost: {d['pointsLost']:.1f}, visits: {d.get('visits', 'N/A')}, settledness: {settled:.1f}, opp_settled: {oppsettled:.1f}, attach: {isattach}, tenuki: {istenuki}", OUTPUT_DEBUG)
-            
+                self.game.katrain.log(
+                    f"[SettleStonesStrategy] #{i + 1}: {move.gtp()} - pt_lost: {d['pointsLost']:.1f}, visits: {d.get('visits', 'N/A')}, settledness: {settled:.1f}, opp_settled: {oppsettled:.1f}, attach: {isattach}, tenuki: {istenuki}",
+                    OUTPUT_DEBUG,
+                )
+
             # Format candidate moves for ai_thoughts
             cands = [
                 f"{move.gtp()} ({d['pointsLost']:.1f} pt lost, {d.get('visits', 'N/A')} visits, {settled:.1f} settledness, {oppsettled:.1f} opponent settledness{', attachment' if isattach else ''}{', tenuki' if istenuki else ''})"
                 for move, settled, oppsettled, isattach, istenuki, d in moves_with_settledness[:5]
             ]
-            
+
             ai_thoughts = f"{AI_SETTLE_STONES} strategy. Top 5 Candidates {', '.join(cands)} "
             aimove = moves_with_settledness[0][0]
-            
+
             self.game.katrain.log(f"[SettleStonesStrategy] Selected move: {aimove.gtp()}", OUTPUT_DEBUG)
         else:
             error_msg = "No moves found - are you using an older KataGo with no per-move ownership info?"
             self.game.katrain.log(f"[SettleStonesStrategy] Error: {error_msg}", OUTPUT_ERROR)
             raise Exception(error_msg)
-        
+
         self.game.katrain.log(f"[SettleStonesStrategy] Final decision: {aimove.gtp()}", OUTPUT_DEBUG)
         return aimove, ai_thoughts
+
 
 @register_strategy(AI_POLICY)
 class PolicyStrategy(AIStrategy):
     """Policy strategy - plays the top move suggested by policy network"""
-    
+
     def generate_move(self) -> Tuple[Move, str]:
-        self.game.katrain.log(f"[PolicyStrategy] Starting move generation", OUTPUT_DEBUG)
+        self.game.katrain.log("[PolicyStrategy] Starting move generation", OUTPUT_DEBUG)
         self.wait_for_analysis()
-        
+
         # Ensure policy is available
         if not self.cn.policy:
-            self.game.katrain.log(f"[PolicyStrategy] No policy data available, falling back to DefaultStrategy", OUTPUT_DEBUG)
+            self.game.katrain.log(
+                "[PolicyStrategy] No policy data available, falling back to DefaultStrategy", OUTPUT_DEBUG
+            )
             return DefaultStrategy(self.game, self.settings).generate_move()
-        
+
         policy_moves = self.cn.policy_ranking
         pass_policy = self.cn.policy[-1]
-        
+
         self.game.katrain.log(f"[PolicyStrategy] Got {len(policy_moves)} policy moves", OUTPUT_DEBUG)
         self.game.katrain.log(f"[PolicyStrategy] Current move depth: {self.cn.depth}", OUTPUT_DEBUG)
-        self.game.katrain.log(f"[PolicyStrategy] Opening moves setting: {self.settings.get('opening_moves', 0)}", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[PolicyStrategy] Opening moves setting: {self.settings.get('opening_moves', 0)}", OUTPUT_DEBUG
+        )
+
         # Log top 5 policy moves
-        self.game.katrain.log(f"[PolicyStrategy] Top 5 policy moves:", OUTPUT_DEBUG)
+        self.game.katrain.log("[PolicyStrategy] Top 5 policy moves:", OUTPUT_DEBUG)
         for i, (prob, move) in enumerate(policy_moves[:5]):
-            self.game.katrain.log(f"[PolicyStrategy] #{i+1}: {move.gtp()} - {prob:.2%}", OUTPUT_DEBUG)
-        
+            self.game.katrain.log(f"[PolicyStrategy] #{i + 1}: {move.gtp()} - {prob:.2%}", OUTPUT_DEBUG)
+
         self.game.katrain.log(f"[PolicyStrategy] Pass policy: {pass_policy:.2%}", OUTPUT_DEBUG)
-        
+
         # Check for pass in top 5
         top_5_pass = any([polmove[1].is_pass for polmove in policy_moves[:5]])
         self.game.katrain.log(f"[PolicyStrategy] Pass in top 5: {top_5_pass}", OUTPUT_DEBUG)
-        
+
         # Handle opening moves override
         if self.cn.depth <= self.settings.get("opening_moves", 0):
-            self.game.katrain.log(f"[PolicyStrategy] In opening phase, using WeightedStrategy instead", OUTPUT_DEBUG)
-            weighted_settings = {
-                "pick_override": 0.9, 
-                "weaken_fac": 1, 
-                "lower_bound": 0.02
-            }
+            self.game.katrain.log("[PolicyStrategy] In opening phase, using WeightedStrategy instead", OUTPUT_DEBUG)
+            weighted_settings = {"pick_override": 0.9, "weaken_fac": 1, "lower_bound": 0.02}
             self.game.katrain.log(f"[PolicyStrategy] Weighted settings: {weighted_settings}", OUTPUT_DEBUG)
             return WeightedStrategy(self.game, weighted_settings).generate_move()
-        
+
         # Check for pass in top 5
         if top_5_pass:
             aimove = policy_moves[0][1]
-            self.game.katrain.log(f"[PolicyStrategy] Playing top move {aimove.gtp()} because pass in top 5", OUTPUT_DEBUG)
+            self.game.katrain.log(
+                f"[PolicyStrategy] Playing top move {aimove.gtp()} because pass in top 5", OUTPUT_DEBUG
+            )
             ai_thoughts = "Playing top one because one of them is pass."
             return aimove, ai_thoughts
-        
+
         # Otherwise play top policy move
         aimove = policy_moves[0][1]
-        self.game.katrain.log(f"[PolicyStrategy] Playing top policy move {aimove.gtp()} with probability {policy_moves[0][0]:.2%}", OUTPUT_DEBUG)
+        self.game.katrain.log(
+            f"[PolicyStrategy] Playing top policy move {aimove.gtp()} with probability {policy_moves[0][0]:.2%}",
+            OUTPUT_DEBUG,
+        )
         ai_thoughts = f"Playing top policy move {aimove.gtp()}."
-        
+
         self.game.katrain.log(f"[PolicyStrategy] Final decision: {aimove.gtp()}", OUTPUT_DEBUG)
         return aimove, ai_thoughts
+
 
 @register_strategy(AI_WEIGHTED)
 class WeightedStrategy(AIStrategy):
     """Weighted strategy - weights moves based on policy and a weakening factor"""
-    
+
     def generate_move(self) -> Tuple[Move, str]:
-        self.game.katrain.log(f"[WeightedStrategy] Starting move generation", OUTPUT_DEBUG)
+        self.game.katrain.log("[WeightedStrategy] Starting move generation", OUTPUT_DEBUG)
         self.wait_for_analysis()
-        
+
         # Ensure policy is available
         if not self.cn.policy:
-            self.game.katrain.log(f"[WeightedStrategy] No policy data available, falling back to DefaultStrategy", OUTPUT_DEBUG)
+            self.game.katrain.log(
+                "[WeightedStrategy] No policy data available, falling back to DefaultStrategy", OUTPUT_DEBUG
+            )
             return DefaultStrategy(self.game, self.settings).generate_move()
-        
+
         policy_moves = self.cn.policy_ranking
         pass_policy = self.cn.policy[-1]
-        
+
         self.game.katrain.log(f"[WeightedStrategy] Got {len(policy_moves)} policy moves", OUTPUT_DEBUG)
-        
+
         # Log top 5 policy moves
-        self.game.katrain.log(f"[WeightedStrategy] Top 5 policy moves:", OUTPUT_DEBUG)
+        self.game.katrain.log("[WeightedStrategy] Top 5 policy moves:", OUTPUT_DEBUG)
         for i, (prob, move) in enumerate(policy_moves[:5]):
-            self.game.katrain.log(f"[WeightedStrategy] #{i+1}: {move.gtp()} - {prob:.2%}", OUTPUT_DEBUG)
-        
+            self.game.katrain.log(f"[WeightedStrategy] #{i + 1}: {move.gtp()} - {prob:.2%}", OUTPUT_DEBUG)
+
         self.game.katrain.log(f"[WeightedStrategy] Pass policy: {pass_policy:.2%}", OUTPUT_DEBUG)
-        
+
         # Check for pass in top 5
         top_5_pass = any([polmove[1].is_pass for polmove in policy_moves[:5]])
         self.game.katrain.log(f"[WeightedStrategy] Pass in top 5: {top_5_pass}", OUTPUT_DEBUG)
-        
+
         # Get override threshold
         override = self.settings.get("pick_override", 0.0)
         self.game.katrain.log(f"[WeightedStrategy] Override threshold: {override:.2%}", OUTPUT_DEBUG)
-        
+
         # Check if we should override with top move
-        override_move, override_thoughts = self.should_play_top_move(
-            policy_moves, 
-            top_5_pass,
-            override=override
-        )
-        
+        override_move, override_thoughts = self.should_play_top_move(policy_moves, top_5_pass, override=override)
+
         if override_move:
             self.game.katrain.log(f"[WeightedStrategy] Using override move: {override_move.gtp()}", OUTPUT_DEBUG)
             return override_move, override_thoughts
-        
+
         # Apply weighted policy move selection
         lower_bound = self.settings.get("lower_bound", 0.02)
         weaken_fac = self.settings.get("weaken_fac", 1.0)
-        
-        self.game.katrain.log(f"[WeightedStrategy] Using weighted selection with lower_bound={lower_bound:.2%}, weaken_fac={weaken_fac}", OUTPUT_DEBUG)
-        
+
+        self.game.katrain.log(
+            f"[WeightedStrategy] Using weighted selection with lower_bound={lower_bound:.2%}, weaken_fac={weaken_fac}",
+            OUTPUT_DEBUG,
+        )
+
         # Generate list of weighted coordinates
         weighted_coords = [
             (pv, pv ** (1 / weaken_fac), move) for pv, move in policy_moves if pv > lower_bound and not move.is_pass
         ]
-        
+
         self.game.katrain.log(f"[WeightedStrategy] Found {len(weighted_coords)} moves above lower bound", OUTPUT_DEBUG)
-        
+
         if weighted_coords:
-            self.game.katrain.log(f"[WeightedStrategy] Performing weighted selection", OUTPUT_DEBUG)
+            self.game.katrain.log("[WeightedStrategy] Performing weighted selection", OUTPUT_DEBUG)
             top = weighted_selection_without_replacement(weighted_coords, 1)[0]
             move = top[2]
             prob = top[0]
-            
-            self.game.katrain.log(f"[WeightedStrategy] Selected move {move.gtp()} with probability {prob:.2%}", OUTPUT_DEBUG)
+
+            self.game.katrain.log(
+                f"[WeightedStrategy] Selected move {move.gtp()} with probability {prob:.2%}", OUTPUT_DEBUG
+            )
             ai_thoughts = f"Playing policy-weighted random move {move.gtp()} ({prob:.1%}) from {len(weighted_coords)} moves above lower_bound of {lower_bound:.1%}."
         else:
             move = policy_moves[0][1]
-            self.game.katrain.log(f"[WeightedStrategy] No moves above lower bound, playing top policy move {move.gtp()}", OUTPUT_DEBUG)
+            self.game.katrain.log(
+                f"[WeightedStrategy] No moves above lower bound, playing top policy move {move.gtp()}", OUTPUT_DEBUG
+            )
             ai_thoughts = f"Playing top policy move because no non-pass move > above lower_bound of {lower_bound:.1%}."
-        
+
         self.game.katrain.log(f"[WeightedStrategy] Final decision: {move.gtp()}", OUTPUT_DEBUG)
         return move, ai_thoughts
 
+
 class PickBasedStrategy(AIStrategy):
     """Base class for pick-based strategies"""
-    
+
     def get_n_moves(self, legal_policy_moves):
         """Calculate the number of moves to consider"""
-        board_squares = self.game.board_size[0] * self.game.board_size[1]
-        
         if self.settings.get("pick_frac") is not None:
             n_moves = max(1, int(self.settings["pick_frac"] * len(legal_policy_moves) + self.settings["pick_n"]))
-            self.game.katrain.log(f"[{self.strategy_name}] Calculated n_moves={n_moves} from pick_frac={self.settings['pick_frac']}, pick_n={self.settings['pick_n']}, legal_moves={len(legal_policy_moves)}", OUTPUT_DEBUG)
+            self.game.katrain.log(
+                f"[{self.strategy_name}] Calculated n_moves={n_moves} from pick_frac={self.settings['pick_frac']}, pick_n={self.settings['pick_n']}, legal_moves={len(legal_policy_moves)}",
+                OUTPUT_DEBUG,
+            )
         else:
             n_moves = 1  # Default
-            self.game.katrain.log(f"[{self.strategy_name}] Using default n_moves={n_moves} (no pick_frac in settings)", OUTPUT_DEBUG)
-            
+            self.game.katrain.log(
+                f"[{self.strategy_name}] Using default n_moves={n_moves} (no pick_frac in settings)", OUTPUT_DEBUG
+            )
+
         return n_moves
-    
+
     def generate_weighted_coords(self, legal_policy_moves, policy_grid, size):
         """Generate weighted coordinates for selection"""
-        self.game.katrain.log(f"[{self.strategy_name}] Generating weighted coordinates (default equal weights implementation)", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Generating weighted coordinates (default equal weights implementation)",
+            OUTPUT_DEBUG,
+        )
+
         # Default implementation for AI_PICK - equal weights
         weighted_coords = [
-            (policy_grid[y][x], 1, x, y)
-            for x in range(size[0])
-            for y in range(size[1])
-            if policy_grid[y][x] > 0
+            (policy_grid[y][x], 1, x, y) for x in range(size[0]) for y in range(size[1]) if policy_grid[y][x] > 0
         ]
-        
-        self.game.katrain.log(f"[{self.strategy_name}] Generated {len(weighted_coords)} weighted coordinates", OUTPUT_DEBUG)
-        
+
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Generated {len(weighted_coords)} weighted coordinates", OUTPUT_DEBUG
+        )
+
         if weighted_coords:
             top5 = heapq.nlargest(5, weighted_coords, key=lambda t: t[0])
             self.game.katrain.log(f"[{self.strategy_name}] Top 5 weighted coordinates by policy value:", OUTPUT_DEBUG)
             for i, (pol, wt, x, y) in enumerate(top5):
-                self.game.katrain.log(f"[{self.strategy_name}] #{i+1}: ({x},{y}) - policy={pol:.2%}, weight={wt}", OUTPUT_DEBUG)
-                
+                self.game.katrain.log(
+                    f"[{self.strategy_name}] #{i + 1}: ({x},{y}) - policy={pol:.2%}, weight={wt}", OUTPUT_DEBUG
+                )
+
         return weighted_coords, "Generated equal weights for all moves. "
-    
+
     def handle_endgame(self, legal_policy_moves, policy_grid, size):
         """Handle special endgame case"""
         board_squares = size[0] * size[1]
         endgame_threshold = self.settings.get("endgame", 0.75) * board_squares
-        
-        self.game.katrain.log(f"[{self.strategy_name}] Checking endgame condition: move depth {self.cn.depth} vs threshold {endgame_threshold}", OUTPUT_DEBUG)
-        
+
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Checking endgame condition: move depth {self.cn.depth} vs threshold {endgame_threshold}",
+            OUTPUT_DEBUG,
+        )
+
         if self.cn.depth > endgame_threshold:
-            self.game.katrain.log(f"[{self.strategy_name}] In endgame phase (move {self.cn.depth} > {endgame_threshold})", OUTPUT_DEBUG)
-            
+            self.game.katrain.log(
+                f"[{self.strategy_name}] In endgame phase (move {self.cn.depth} > {endgame_threshold})", OUTPUT_DEBUG
+            )
+
             weighted_coords = [(pol, 1, *mv.coords) for pol, mv in legal_policy_moves]
             ai_thoughts = f"Generated equal weights as move number >= {self.settings['endgame'] * size[0] * size[1]}. "
-            
+
             n_moves = int(max(self.get_n_moves(legal_policy_moves), len(legal_policy_moves) // 2))
             self.game.katrain.log(f"[{self.strategy_name}] Using endgame n_moves={n_moves}", OUTPUT_DEBUG)
-            
-            self.game.katrain.log(f"[{self.strategy_name}] Generated {len(weighted_coords)} weighted coordinates for endgame", OUTPUT_DEBUG)
-            
+
+            self.game.katrain.log(
+                f"[{self.strategy_name}] Generated {len(weighted_coords)} weighted coordinates for endgame",
+                OUTPUT_DEBUG,
+            )
+
             return weighted_coords, ai_thoughts, n_moves, True
-            
+
         self.game.katrain.log(f"[{self.strategy_name}] Not in endgame phase yet", OUTPUT_DEBUG)
         return None, "", None, False
-    
+
     def select_from_weighted_coords(self, weighted_coords, n_moves, pass_policy):
         """Select moves from weighted coordinates"""
-        self.game.katrain.log(f"[{self.strategy_name}] Selecting from {len(weighted_coords)} weighted coordinates, n_moves={n_moves}", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Selecting from {len(weighted_coords)} weighted coordinates, n_moves={n_moves}",
+            OUTPUT_DEBUG,
+        )
+
         # Perform weighted selection
         pick_moves = weighted_selection_without_replacement(weighted_coords, n_moves)
         self.game.katrain.log(f"[{self.strategy_name}] Picked {len(pick_moves)} moves", OUTPUT_DEBUG)
-        
+
         if pick_moves:
             # Get top 5 from picked moves
             top_picked = heapq.nlargest(5, pick_moves)
             self.game.katrain.log(f"[{self.strategy_name}] Top 5 after selection:", OUTPUT_DEBUG)
             for i, (p, wt, x, y) in enumerate(top_picked):
-                self.game.katrain.log(f"[{self.strategy_name}] #{i+1}: ({x},{y}) - policy={p:.2%}, weight={wt}", OUTPUT_DEBUG)
-            
+                self.game.katrain.log(
+                    f"[{self.strategy_name}] #{i + 1}: ({x},{y}) - policy={p:.2%}, weight={wt}", OUTPUT_DEBUG
+                )
+
             # Convert to move objects
-            new_top = [
-                (p, Move((x, y), player=self.cn.next_player)) for p, wt, x, y in top_picked
-            ]
-            
+            new_top = [(p, Move((x, y), player=self.cn.next_player)) for p, wt, x, y in top_picked]
+
             aimove = new_top[0][1]
             ai_thoughts = f"Top 5 among these were {fmt_moves(new_top)} and picked top {aimove.gtp()}. "
-            
-            self.game.katrain.log(f"[{self.strategy_name}] Top picked move: {aimove.gtp()} ({new_top[0][0]:.2%})", OUTPUT_DEBUG)
+
+            self.game.katrain.log(
+                f"[{self.strategy_name}] Top picked move: {aimove.gtp()} ({new_top[0][0]:.2%})", OUTPUT_DEBUG
+            )
             self.game.katrain.log(f"[{self.strategy_name}] Pass policy: {pass_policy:.2%}", OUTPUT_DEBUG)
-            
+
             # Check if pass is better
             if new_top[0][0] < pass_policy:
-                self.game.katrain.log(f"[{self.strategy_name}] Pass policy {pass_policy:.2%} is better than top move {aimove.gtp()} ({new_top[0][0]:.2%}), switching to top policy move", OUTPUT_DEBUG)
-                
+                self.game.katrain.log(
+                    f"[{self.strategy_name}] Pass policy {pass_policy:.2%} is better than top move {aimove.gtp()} ({new_top[0][0]:.2%}), switching to top policy move",
+                    OUTPUT_DEBUG,
+                )
+
                 policy_moves = self.cn.policy_ranking
                 top_policy_move = policy_moves[0][1]
-                
+
                 ai_thoughts += f"But found pass ({pass_policy:.2%} to be higher rated than {aimove.gtp()} ({new_top[0][0]:.2%}) so will play top policy move instead."
                 aimove = top_policy_move
-                
-                self.game.katrain.log(f"[{self.strategy_name}] Final move (after pass check): {aimove.gtp()}", OUTPUT_DEBUG)
+
+                self.game.katrain.log(
+                    f"[{self.strategy_name}] Final move (after pass check): {aimove.gtp()}", OUTPUT_DEBUG
+                )
             else:
                 self.game.katrain.log(f"[{self.strategy_name}] Top move is better than pass, keeping it", OUTPUT_DEBUG)
         else:
-            self.game.katrain.log(f"[{self.strategy_name}] No moves selected, falling back to top policy move", OUTPUT_DEBUG)
-            
+            self.game.katrain.log(
+                f"[{self.strategy_name}] No moves selected, falling back to top policy move", OUTPUT_DEBUG
+            )
+
             policy_moves = self.cn.policy_ranking
             top_policy_move = policy_moves[0][1]
             aimove = top_policy_move
-            
-            ai_thoughts = f"Pick policy strategy failed to find legal moves, so is playing top policy move {aimove.gtp()}."
-            
+
+            ai_thoughts = (
+                f"Pick policy strategy failed to find legal moves, so is playing top policy move {aimove.gtp()}."
+            )
+
             self.game.katrain.log(f"[{self.strategy_name}] Final move (fallback): {aimove.gtp()}", OUTPUT_DEBUG)
-            
+
         return aimove, ai_thoughts
-    
+
     def generate_move(self) -> Tuple[Move, str]:
         self.game.katrain.log(f"[{self.strategy_name}] Starting move generation", OUTPUT_DEBUG)
         self.wait_for_analysis()
-        
+
         # Ensure policy is available
         if not self.cn.policy:
-            self.game.katrain.log(f"[{self.strategy_name}] No policy data available, falling back to DefaultStrategy", OUTPUT_DEBUG)
+            self.game.katrain.log(
+                f"[{self.strategy_name}] No policy data available, falling back to DefaultStrategy", OUTPUT_DEBUG
+            )
             return DefaultStrategy(self.game, self.settings).generate_move()
-        
+
         policy_moves = self.cn.policy_ranking
         pass_policy = self.cn.policy[-1]
-        
+
         self.game.katrain.log(f"[{self.strategy_name}] Got {len(policy_moves)} policy moves", OUTPUT_DEBUG)
-        
+
         # Log top 5 policy moves
         self.game.katrain.log(f"[{self.strategy_name}] Top 5 policy moves:", OUTPUT_DEBUG)
         for i, (prob, move) in enumerate(policy_moves[:5]):
-            self.game.katrain.log(f"[{self.strategy_name}] #{i+1}: {move.gtp()} - {prob:.2%}", OUTPUT_DEBUG)
-        
+            self.game.katrain.log(f"[{self.strategy_name}] #{i + 1}: {move.gtp()} - {prob:.2%}", OUTPUT_DEBUG)
+
         self.game.katrain.log(f"[{self.strategy_name}] Pass policy: {pass_policy:.2%}", OUTPUT_DEBUG)
-        
+
         # Check for pass in top 5
         top_5_pass = any([polmove[1].is_pass for polmove in policy_moves[:5]])
         self.game.katrain.log(f"[{self.strategy_name}] Pass in top 5: {top_5_pass}", OUTPUT_DEBUG)
-        
+
         # Get override settings
         override = self.settings.get("pick_override", 0.0)
         overridetwo = self.settings.get("pick_override_two", 1.0)
-        self.game.katrain.log(f"[{self.strategy_name}] Override settings: single={override:.2%}, combined={overridetwo:.2%}", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Override settings: single={override:.2%}, combined={overridetwo:.2%}", OUTPUT_DEBUG
+        )
+
         # Check if we should override with top move
         override_move, override_thoughts = self.should_play_top_move(
-            policy_moves, 
-            top_5_pass,
-            override=override,
-            overridetwo=overridetwo
+            policy_moves, top_5_pass, override=override, overridetwo=overridetwo
         )
-        
+
         if override_move:
             self.game.katrain.log(f"[{self.strategy_name}] Using override move: {override_move.gtp()}", OUTPUT_DEBUG)
             return override_move, override_thoughts
-        
+
         # Get legal policy moves
         legal_policy_moves = [(pol, mv) for pol, mv in policy_moves if not mv.is_pass and pol > 0]
-        self.game.katrain.log(f"[{self.strategy_name}] Found {len(legal_policy_moves)} legal non-pass policy moves", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[{self.strategy_name}] Found {len(legal_policy_moves)} legal non-pass policy moves", OUTPUT_DEBUG
+        )
+
         # Create policy grid
-# Create policy grid
+        # Create policy grid
         size = self.game.board_size
         self.game.katrain.log(f"[{self.strategy_name}] Board size: {size}", OUTPUT_DEBUG)
         policy_grid = var_to_grid(self.cn.policy, size)
-        
+
         # Check for endgame
         end_coords, end_thoughts, end_n_moves, is_endgame = self.handle_endgame(legal_policy_moves, policy_grid, size)
-        
+
         if is_endgame:
             self.game.katrain.log(f"[{self.strategy_name}] Using endgame logic", OUTPUT_DEBUG)
             return self.select_from_weighted_coords(end_coords, end_n_moves, pass_policy)
-        
+
         # Get weighted coordinates
         self.game.katrain.log(f"[{self.strategy_name}] Generating weighted coordinates", OUTPUT_DEBUG)
         weighted_coords, weight_thoughts = self.generate_weighted_coords(legal_policy_moves, policy_grid, size)
-        
+
         # Get number of moves to consider
         n_moves = self.get_n_moves(legal_policy_moves)
         self.game.katrain.log(f"[{self.strategy_name}] Using n_moves={n_moves}", OUTPUT_DEBUG)
-        
-        ai_thoughts = weight_thoughts + f"Picked {min(n_moves, len(weighted_coords))} random moves according to weights. "
-        
+
+        ai_thoughts = (
+            weight_thoughts + f"Picked {min(n_moves, len(weighted_coords))} random moves according to weights. "
+        )
+
         # Select and return move
         self.game.katrain.log(f"[{self.strategy_name}] Selecting move from weighted coordinates", OUTPUT_DEBUG)
         move, thoughts = self.select_from_weighted_coords(weighted_coords, n_moves, pass_policy)
-        
+
         self.game.katrain.log(f"[{self.strategy_name}] Final decision: {move.gtp()}", OUTPUT_DEBUG)
         return move, ai_thoughts + thoughts
+
 
 @register_strategy(AI_PICK)
 class PickStrategy(PickBasedStrategy):
     """Pick strategy - picks a move from a subset of legal moves"""
-    
+
     def generate_move(self) -> Tuple[Move, str]:
-        self.game.katrain.log(f"[PickStrategy] Starting move generation using base PickBasedStrategy implementation", OUTPUT_DEBUG)
+        self.game.katrain.log(
+            "[PickStrategy] Starting move generation using base PickBasedStrategy implementation", OUTPUT_DEBUG
+        )
         return super().generate_move()
 
     def handle_endgame(self, legal_policy_moves, policy_grid, size):
         return None, "", None, False
 
+
 @register_strategy(AI_RANK)
 class RankStrategy(PickBasedStrategy):
     """Rank strategy - similar to Pick but calibrated based on rank"""
-    
+
     def get_n_moves(self, legal_policy_moves):
         """Calculate n_moves based on rank"""
-        self.game.katrain.log(f"[RankStrategy] Calculating n_moves based on rank", OUTPUT_DEBUG)
-        
+        self.game.katrain.log("[RankStrategy] Calculating n_moves based on rank", OUTPUT_DEBUG)
+
         size = self.game.board_size
         board_squares = size[0] * size[1]
         norm_leg_moves = len(legal_policy_moves) / board_squares
-        
+
         self.game.katrain.log(f"[RankStrategy] Board squares: {board_squares}", OUTPUT_DEBUG)
         self.game.katrain.log(f"[RankStrategy] Legal moves: {len(legal_policy_moves)}", OUTPUT_DEBUG)
         self.game.katrain.log(f"[RankStrategy] Normalized legal moves: {norm_leg_moves:.4f}", OUTPUT_DEBUG)
         self.game.katrain.log(f"[RankStrategy] Kyu rank: {self.settings['kyu_rank']}", OUTPUT_DEBUG)
-        
+
         # Calculate n_moves using the rank formula
         orig_calib_avemodrank = 0.063015 + 0.7624 * board_squares / (
             10 ** (-0.05737 * self.settings["kyu_rank"] + 1.9482)
         )
-        
-        self.game.katrain.log(f"[RankStrategy] Original calibrated average mod rank: {orig_calib_avemodrank:.4f}", OUTPUT_DEBUG)
-        
+
+        self.game.katrain.log(
+            f"[RankStrategy] Original calibrated average mod rank: {orig_calib_avemodrank:.4f}", OUTPUT_DEBUG
+        )
+
         exponent_term = (
-            3.002 * norm_leg_moves * norm_leg_moves
-            - norm_leg_moves
-            - 0.034889 * self.settings["kyu_rank"]
-            - 0.5097
+            3.002 * norm_leg_moves * norm_leg_moves - norm_leg_moves - 0.034889 * self.settings["kyu_rank"] - 0.5097
         )
         self.game.katrain.log(f"[RankStrategy] Exponent term: {exponent_term:.4f}", OUTPUT_DEBUG)
-        
+
         modified_calib_avemodrank = (
-            0.3931
-            + 0.6559
-            * norm_leg_moves
-            * math.exp(-1 * exponent_term ** 2)
-            - 0.01093 * self.settings["kyu_rank"]
+            0.3931 + 0.6559 * norm_leg_moves * math.exp(-1 * exponent_term**2) - 0.01093 * self.settings["kyu_rank"]
         ) * orig_calib_avemodrank
-        
-        self.game.katrain.log(f"[RankStrategy] Modified calibrated average mod rank: {modified_calib_avemodrank:.4f}", OUTPUT_DEBUG)
-        
+
+        self.game.katrain.log(
+            f"[RankStrategy] Modified calibrated average mod rank: {modified_calib_avemodrank:.4f}", OUTPUT_DEBUG
+        )
+
         denominator = 1.31165 * (modified_calib_avemodrank + 1) - 0.082653
         self.game.katrain.log(f"[RankStrategy] Denominator: {denominator:.4f}", OUTPUT_DEBUG)
-        
+
         n_moves = board_squares * norm_leg_moves / denominator
         n_moves = max(1, round(n_moves))
-        
+
         self.game.katrain.log(f"[RankStrategy] Calculated n_moves: {n_moves}", OUTPUT_DEBUG)
-        
+
         return n_moves
-    
+
     def should_play_top_move(self, policy_moves, top_5_pass, override=0.0, overridetwo=1.0):
         """Special override logic for rank-based"""
-        self.game.katrain.log(f"[RankStrategy] Calculating special override thresholds based on rank", OUTPUT_DEBUG)
-        
+        self.game.katrain.log("[RankStrategy] Calculating special override thresholds based on rank", OUTPUT_DEBUG)
+
         size = self.game.board_size
         board_squares = size[0] * size[1]
         legal_policy_moves = [(pol, mv) for pol, mv in policy_moves if not mv.is_pass and pol > 0]
-        
+
         # Parameters for calculating the overrides
         self.game.katrain.log(f"[RankStrategy] Board squares: {board_squares}", OUTPUT_DEBUG)
         self.game.katrain.log(f"[RankStrategy] Legal non-pass moves: {len(legal_policy_moves)}", OUTPUT_DEBUG)
         self.game.katrain.log(f"[RankStrategy] Kyu rank: {self.settings['kyu_rank']}", OUTPUT_DEBUG)
-        
+
         # Calibrated override based on board filling
         ratio = (board_squares - len(legal_policy_moves)) / board_squares
         override = 0.8 * (1 - 0.5 * ratio)
-        self.game.katrain.log(f"[RankStrategy] Calculated override: {override:.2%} (from board filling ratio {ratio:.2f})", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[RankStrategy] Calculated override: {override:.2%} (from board filling ratio {ratio:.2f})", OUTPUT_DEBUG
+        )
+
         overridetwo = 0.85 + max(0, 0.02 * (self.settings["kyu_rank"] - 8))
-        self.game.katrain.log(f"[RankStrategy] Calculated overridetwo: {overridetwo:.2%} (from kyu rank adjustment)", OUTPUT_DEBUG)
-        
+        self.game.katrain.log(
+            f"[RankStrategy] Calculated overridetwo: {overridetwo:.2%} (from kyu rank adjustment)", OUTPUT_DEBUG
+        )
+
         # Call the parent class method with calculated overrides
         return super().should_play_top_move(policy_moves, top_5_pass, override, overridetwo)
 
     def handle_endgame(self, legal_policy_moves, policy_grid, size):
         return None, "", None, False
 
+
 @register_strategy(AI_INFLUENCE)
 class InfluenceStrategy(PickBasedStrategy):
     """Influence strategy - weights moves based on influence (distance from edge)"""
-    
+
     def generate_weighted_coords(self, legal_policy_moves, policy_grid, size):
         """Generate influence-based weights"""
-        self.game.katrain.log(f"[InfluenceStrategy] Generating influence-based weights", OUTPUT_DEBUG)
-        self.game.katrain.log(f"[InfluenceStrategy] Settings: threshold={self.settings['threshold']}, line_weight={self.settings['line_weight']}", OUTPUT_DEBUG)
-        weighted_coords, ai_thoughts = generate_influence_territory_weights(
-            AI_INFLUENCE, 
-            self.settings, 
-            policy_grid, 
-            size
+        self.game.katrain.log("[InfluenceStrategy] Generating influence-based weights", OUTPUT_DEBUG)
+        self.game.katrain.log(
+            f"[InfluenceStrategy] Settings: threshold={self.settings['threshold']}, line_weight={self.settings['line_weight']}",
+            OUTPUT_DEBUG,
         )
-        self.game.katrain.log(f"[InfluenceStrategy] Generated {len(weighted_coords)} weighted coordinates", OUTPUT_DEBUG)
+        weighted_coords, ai_thoughts = generate_influence_territory_weights(
+            AI_INFLUENCE, self.settings, policy_grid, size
+        )
+        self.game.katrain.log(
+            f"[InfluenceStrategy] Generated {len(weighted_coords)} weighted coordinates", OUTPUT_DEBUG
+        )
         if weighted_coords:
             top5 = heapq.nlargest(5, weighted_coords, key=lambda t: t[0] * t[1])
-            self.game.katrain.log(f"[InfluenceStrategy] Top 5 weighted coordinates (by policy*weight):", OUTPUT_DEBUG)
+            self.game.katrain.log("[InfluenceStrategy] Top 5 weighted coordinates (by policy*weight):", OUTPUT_DEBUG)
             for i, (pol, wt, x, y) in enumerate(top5):
-                self.game.katrain.log(f"[InfluenceStrategy] #{i+1}: ({x},{y}) - policy={pol:.2%}, weight={wt}, combined={pol*wt:.2%}", OUTPUT_DEBUG)
+                self.game.katrain.log(
+                    f"[InfluenceStrategy] #{i + 1}: ({x},{y}) - policy={pol:.2%}, weight={wt}, combined={pol * wt:.2%}",
+                    OUTPUT_DEBUG,
+                )
         return weighted_coords, ai_thoughts
+
 
 @register_strategy(AI_TERRITORY)
 class TerritoryStrategy(PickBasedStrategy):
     """Territory strategy - weights moves based on territory (distance from center)"""
-    
+
     def generate_weighted_coords(self, legal_policy_moves, policy_grid, size):
         """Generate territory-based weights"""
-        self.game.katrain.log(f"[TerritoryStrategy] Generating territory-based weights", OUTPUT_DEBUG)
-        self.game.katrain.log(f"[TerritoryStrategy] Settings: threshold={self.settings['threshold']}, line_weight={self.settings['line_weight']}", OUTPUT_DEBUG)
-        weighted_coords, ai_thoughts = generate_influence_territory_weights(
-            AI_TERRITORY, 
-            self.settings, 
-            policy_grid, 
-            size
+        self.game.katrain.log("[TerritoryStrategy] Generating territory-based weights", OUTPUT_DEBUG)
+        self.game.katrain.log(
+            f"[TerritoryStrategy] Settings: threshold={self.settings['threshold']}, line_weight={self.settings['line_weight']}",
+            OUTPUT_DEBUG,
         )
-        self.game.katrain.log(f"[TerritoryStrategy] Generated {len(weighted_coords)} weighted coordinates", OUTPUT_DEBUG)
+        weighted_coords, ai_thoughts = generate_influence_territory_weights(
+            AI_TERRITORY, self.settings, policy_grid, size
+        )
+        self.game.katrain.log(
+            f"[TerritoryStrategy] Generated {len(weighted_coords)} weighted coordinates", OUTPUT_DEBUG
+        )
         if weighted_coords:
             top5 = heapq.nlargest(5, weighted_coords, key=lambda t: t[0] * t[1])
-            self.game.katrain.log(f"[TerritoryStrategy] Top 5 weighted coordinates (by policy*weight):", OUTPUT_DEBUG)
+            self.game.katrain.log("[TerritoryStrategy] Top 5 weighted coordinates (by policy*weight):", OUTPUT_DEBUG)
             for i, (pol, wt, x, y) in enumerate(top5):
-                self.game.katrain.log(f"[TerritoryStrategy] #{i+1}: ({x},{y}) - policy={pol:.2%}, weight={wt}, combined={pol*wt:.2%}", OUTPUT_DEBUG)
+                self.game.katrain.log(
+                    f"[TerritoryStrategy] #{i + 1}: ({x},{y}) - policy={pol:.2%}, weight={wt}, combined={pol * wt:.2%}",
+                    OUTPUT_DEBUG,
+                )
         return weighted_coords, ai_thoughts
+
 
 @register_strategy(AI_LOCAL)
 class LocalStrategy(PickBasedStrategy):
     """Local strategy - weights moves based on proximity to the last move"""
-    
+
     def generate_move(self) -> Tuple[Move, str]:
         # Handle the case where there's no previous move
         if not (self.cn.move and self.cn.move.coords):
-            self.game.katrain.log(f"[LocalStrategy] No previous move with valid coordinates found, falling back to WeightedStrategy", OUTPUT_DEBUG)
-            self.game.katrain.log(f"[LocalStrategy] Using default weighted settings: pick_override=0.9, weaken_fac=1, lower_bound=0.02", OUTPUT_DEBUG)
-            return WeightedStrategy(self.game, {
-                "pick_override": 0.9, 
-                "weaken_fac": 1, 
-                "lower_bound": 0.02
-            }).generate_move()
-        
+            self.game.katrain.log(
+                "[LocalStrategy] No previous move with valid coordinates found, falling back to WeightedStrategy",
+                OUTPUT_DEBUG,
+            )
+            self.game.katrain.log(
+                "[LocalStrategy] Using default weighted settings: pick_override=0.9, weaken_fac=1, lower_bound=0.02",
+                OUTPUT_DEBUG,
+            )
+            return WeightedStrategy(
+                self.game, {"pick_override": 0.9, "weaken_fac": 1, "lower_bound": 0.02}
+            ).generate_move()
+
         return super().generate_move()
-    
+
     def generate_weighted_coords(self, legal_policy_moves, policy_grid, size):
         """Generate local-based weights"""
-        self.game.katrain.log(f"[LocalStrategy] Generating local-based weights around previous move", OUTPUT_DEBUG)
+        self.game.katrain.log("[LocalStrategy] Generating local-based weights around previous move", OUTPUT_DEBUG)
         self.game.katrain.log(f"[LocalStrategy] Previous move: {self.cn.move.gtp()}", OUTPUT_DEBUG)
         self.game.katrain.log(f"[LocalStrategy] Variance setting: {self.settings['stddev']}", OUTPUT_DEBUG)
         weighted_coords, ai_thoughts = generate_local_tenuki_weights(
-            AI_LOCAL, 
-            self.settings, 
-            policy_grid, 
-            self.cn, 
-            size
+            AI_LOCAL, self.settings, policy_grid, self.cn, size
         )
         self.game.katrain.log(f"[LocalStrategy] Generated {len(weighted_coords)} weighted coordinates", OUTPUT_DEBUG)
         if weighted_coords:
             top5 = heapq.nlargest(5, weighted_coords, key=lambda t: t[0] * t[1])
-            self.game.katrain.log(f"[LocalStrategy] Top 5 weighted coordinates (by policy*weight):", OUTPUT_DEBUG)
+            self.game.katrain.log("[LocalStrategy] Top 5 weighted coordinates (by policy*weight):", OUTPUT_DEBUG)
             for i, (pol, wt, x, y) in enumerate(top5):
-                self.game.katrain.log(f"[LocalStrategy] #{i+1}: ({x},{y}) - policy={pol:.2%}, weight={wt}, combined={pol*wt:.2%}", OUTPUT_DEBUG)
+                self.game.katrain.log(
+                    f"[LocalStrategy] #{i + 1}: ({x},{y}) - policy={pol:.2%}, weight={wt}, combined={pol * wt:.2%}",
+                    OUTPUT_DEBUG,
+                )
         return weighted_coords, ai_thoughts
+
 
 @register_strategy(AI_TENUKI)
 class TenukiStrategy(PickBasedStrategy):
     """Tenuki strategy - weights moves based on distance from the last move"""
-    
+
     def generate_move(self) -> Tuple[Move, str]:
         # Handle the case where there's no previous move
         if not (self.cn.move and self.cn.move.coords):
-            self.game.katrain.log(f"[TenukiStrategy] No previous move with valid coordinates found, falling back to WeightedStrategy", OUTPUT_DEBUG)
-            self.game.katrain.log(f"[TenukiStrategy] Using default weighted settings: pick_override=0.9, weaken_fac=1, lower_bound=0.02", OUTPUT_DEBUG)
-            return WeightedStrategy(self.game, {
-                "pick_override": 0.9, 
-                "weaken_fac": 1, 
-                "lower_bound": 0.02
-            }).generate_move()
-        
+            self.game.katrain.log(
+                "[TenukiStrategy] No previous move with valid coordinates found, falling back to WeightedStrategy",
+                OUTPUT_DEBUG,
+            )
+            self.game.katrain.log(
+                "[TenukiStrategy] Using default weighted settings: pick_override=0.9, weaken_fac=1, lower_bound=0.02",
+                OUTPUT_DEBUG,
+            )
+            return WeightedStrategy(
+                self.game, {"pick_override": 0.9, "weaken_fac": 1, "lower_bound": 0.02}
+            ).generate_move()
+
         return super().generate_move()
-    
+
     def generate_weighted_coords(self, legal_policy_moves, policy_grid, size):
         """Generate tenuki-based weights"""
-        self.game.katrain.log(f"[TenukiStrategy] Generating tenuki-based weights (far from previous move)", OUTPUT_DEBUG)
+        self.game.katrain.log("[TenukiStrategy] Generating tenuki-based weights (far from previous move)", OUTPUT_DEBUG)
         self.game.katrain.log(f"[TenukiStrategy] Previous move: {self.cn.move.gtp()}", OUTPUT_DEBUG)
         self.game.katrain.log(f"[TenukiStrategy] Variance setting: {self.settings['stddev']}", OUTPUT_DEBUG)
         weighted_coords, ai_thoughts = generate_local_tenuki_weights(
-            AI_TENUKI, 
-            self.settings, 
-            policy_grid, 
-            self.cn, 
-            size
+            AI_TENUKI, self.settings, policy_grid, self.cn, size
         )
         self.game.katrain.log(f"[TenukiStrategy] Generated {len(weighted_coords)} weighted coordinates", OUTPUT_DEBUG)
         if weighted_coords:
             top5 = heapq.nlargest(5, weighted_coords, key=lambda t: t[0] * t[1])
-            self.game.katrain.log(f"[TenukiStrategy] Top 5 weighted coordinates (by policy*weight):", OUTPUT_DEBUG)
+            self.game.katrain.log("[TenukiStrategy] Top 5 weighted coordinates (by policy*weight):", OUTPUT_DEBUG)
             for i, (pol, wt, x, y) in enumerate(top5):
-                self.game.katrain.log(f"[TenukiStrategy] #{i+1}: ({x},{y}) - policy={pol:.2%}, weight={wt}, combined={pol*wt:.2%}", OUTPUT_DEBUG)
+                self.game.katrain.log(
+                    f"[TenukiStrategy] #{i + 1}: ({x},{y}) - policy={pol:.2%}, weight={wt}, combined={pol * wt:.2%}",
+                    OUTPUT_DEBUG,
+                )
         return weighted_coords, ai_thoughts
+
 
 @register_strategy(AI_HUMAN)
 @register_strategy(AI_PRO)
 class HumanStyleStrategy(AIStrategy):
     """Strategy that imitates human play at various skill levels"""
-    
+
     def __init__(self, game: Game, ai_settings: Dict):
         super().__init__(game, ai_settings)
-        self.game.katrain.log(f"[HumanStyleStrategy] Initializing HumanStyleStrategy", OUTPUT_DEBUG)
+        self.game.katrain.log("[HumanStyleStrategy] Initializing HumanStyleStrategy", OUTPUT_DEBUG)
         self.game.katrain.log(f"[HumanStyleStrategy] AI settings: {ai_settings}", OUTPUT_DEBUG)
-        
+
     def generate_move(self) -> Tuple[Move, str]:
-        self.game.katrain.log(f"[HumanStyleStrategy] Starting move generation", OUTPUT_DEBUG)
-        
+        self.game.katrain.log("[HumanStyleStrategy] Starting move generation", OUTPUT_DEBUG)
+
         if "human_kyu_rank" in self.settings:
             human_kyu_rank = round(self.settings["human_kyu_rank"])
             human_style = "rank" if self.settings["modern_style"] else "preaz"
 
             if human_kyu_rank <= 0:  # dan ranks
-                rank_text = f"{1-human_kyu_rank}d"
+                rank_text = f"{1 - human_kyu_rank}d"
             else:  # kyu ranks
                 rank_text = f"{human_kyu_rank}k"
 
@@ -1314,94 +1560,113 @@ class HumanStyleStrategy(AIStrategy):
         else:
             pro_year = round(self.settings["pro_year"])
             human_profile = f"proyear_{pro_year}"
-        
+
         self.game.katrain.log(f"[HumanStyleStrategy] Human profile string: {human_profile}", OUTPUT_DEBUG)
-        
+
         # Define override settings (separate from includePolicy)
         override_settings = {
             "humanSLProfile": human_profile,
             "ignorePreRootHistory": False,
         }
         self.game.katrain.log(f"[HumanStyleStrategy] Override settings for engine: {override_settings}", OUTPUT_DEBUG)
-        
+
         # Request analysis from engine - note includePolicy is a direct parameter
         analysis = None
-        
+
         def set_analysis(a, partial_result):
             nonlocal analysis
             if not partial_result:
-                self.game.katrain.log(f"[HumanStyleStrategy] Full analysis results received", OUTPUT_DEBUG)
+                self.game.katrain.log("[HumanStyleStrategy] Full analysis results received", OUTPUT_DEBUG)
                 analysis = a
                 # Log some analysis stats for debugging
                 if a:
-                    self.game.katrain.log(f"[HumanStyleStrategy] Analysis contains humanPolicy: {'humanPolicy' in a}", OUTPUT_DEBUG)
-                    self.game.katrain.log(f"[HumanStyleStrategy] Analysis contains moveInfos: {len(a.get('moveInfos', []))} moves", OUTPUT_DEBUG)
-                    if 'humanPolicy' in a:
-                        policy_sum = sum(a['humanPolicy'])
-                        policy_max = max(a['humanPolicy'])
-                        self.game.katrain.log(f"[HumanStyleStrategy] Human policy sum: {policy_sum}, max: {policy_max}", OUTPUT_DEBUG)
+                    self.game.katrain.log(
+                        f"[HumanStyleStrategy] Analysis contains humanPolicy: {'humanPolicy' in a}", OUTPUT_DEBUG
+                    )
+                    self.game.katrain.log(
+                        f"[HumanStyleStrategy] Analysis contains moveInfos: {len(a.get('moveInfos', []))} moves",
+                        OUTPUT_DEBUG,
+                    )
+                    if "humanPolicy" in a:
+                        policy_sum = sum(a["humanPolicy"])
+                        policy_max = max(a["humanPolicy"])
+                        self.game.katrain.log(
+                            f"[HumanStyleStrategy] Human policy sum: {policy_sum}, max: {policy_max}", OUTPUT_DEBUG
+                        )
             else:
-                self.game.katrain.log(f"[HumanStyleStrategy] Received partial analysis results - ignoring", OUTPUT_DEBUG)
+                self.game.katrain.log("[HumanStyleStrategy] Received partial analysis results - ignoring", OUTPUT_DEBUG)
 
         def set_error(a):
             nonlocal error
             error = True
             self.game.katrain.log(f"[HumanStyleStrategy] Error in human analysis query: {a}", OUTPUT_ERROR)
-            self.game.katrain.log(f"[HumanStyleStrategy] Will attempt to fall back to policy move", OUTPUT_DEBUG)
-            
+            self.game.katrain.log("[HumanStyleStrategy] Will attempt to fall back to policy move", OUTPUT_DEBUG)
+
         error = False
-        self.game.katrain.log(f"[HumanStyleStrategy] Getting engine for player", OUTPUT_DEBUG)
+        self.game.katrain.log("[HumanStyleStrategy] Getting engine for player", OUTPUT_DEBUG)
         engine = self.game.engines[self.cn.player]
         self.game.katrain.log(f"[HumanStyleStrategy] Using engine for player {self.cn.player}", OUTPUT_DEBUG)
-        
-        self.game.katrain.log(f"[HumanStyleStrategy] Requesting analysis with human profile settings", OUTPUT_DEBUG)
+
+        self.game.katrain.log("[HumanStyleStrategy] Requesting analysis with human profile settings", OUTPUT_DEBUG)
         engine.request_analysis(
             self.cn,
             callback=set_analysis,
             error_callback=set_error,
             priority=PRIORITY_EXTRA_AI_QUERY,
             include_policy=True,
-            extra_settings=override_settings
+            extra_settings=override_settings,
         )
-        self.game.katrain.log(f"[HumanStyleStrategy] Analysis request sent, waiting for results", OUTPUT_DEBUG)
-        
+        self.game.katrain.log("[HumanStyleStrategy] Analysis request sent, waiting for results", OUTPUT_DEBUG)
+
         # Wait for analysis to complete
         wait_count = 0
         while not (error or analysis):
             import time
+
             time.sleep(0.01)
             wait_count += 1
             if wait_count % 100 == 0:  # Log every 1 second
-                self.game.katrain.log(f"[HumanStyleStrategy] Still waiting for analysis results ({wait_count/100:.1f}s)", OUTPUT_DEBUG)
+                self.game.katrain.log(
+                    f"[HumanStyleStrategy] Still waiting for analysis results ({wait_count / 100:.1f}s)", OUTPUT_DEBUG
+                )
             engine.check_alive(exception_if_dead=True)
-        
-        self.game.katrain.log(f"[HumanStyleStrategy] Finished waiting for analysis, error={error}, analysis received={analysis is not None}", OUTPUT_DEBUG)
-            
+
+        self.game.katrain.log(
+            f"[HumanStyleStrategy] Finished waiting for analysis, error={error}, analysis received={analysis is not None}",
+            OUTPUT_DEBUG,
+        )
+
         if error or not analysis:
-            self.game.katrain.log(f"[HumanStyleStrategy] Analysis failed or returned empty", OUTPUT_DEBUG)
+            self.game.katrain.log("[HumanStyleStrategy] Analysis failed or returned empty", OUTPUT_DEBUG)
             # Fall back to policy
             policy_move = self.cn.policy_ranking[0][1] if self.cn.policy_ranking else None
             if policy_move:
-                self.game.katrain.log(f"[HumanStyleStrategy] Falling back to top policy move: {policy_move.gtp()}", OUTPUT_DEBUG)
+                self.game.katrain.log(
+                    f"[HumanStyleStrategy] Falling back to top policy move: {policy_move.gtp()}", OUTPUT_DEBUG
+                )
                 return policy_move, "Falling back to policy move due to error in human analysis."
             else:
-                self.game.katrain.log(f"[HumanStyleStrategy] No policy moves available for fallback - will return pass", OUTPUT_DEBUG)
+                self.game.katrain.log(
+                    "[HumanStyleStrategy] No policy moves available for fallback - will return pass", OUTPUT_DEBUG
+                )
                 return Move(None, player=self.cn.next_player), "No valid moves found."
-        
+
         # Check if human policy is available
-        self.game.katrain.log(f"[HumanStyleStrategy] Processing analysis results", OUTPUT_DEBUG)
+        self.game.katrain.log("[HumanStyleStrategy] Processing analysis results", OUTPUT_DEBUG)
         if "humanPolicy" not in analysis:
             error_msg = "humanPolicy not found in analysis—have you downloaded and configured your human model yet?"
             raise Exception(error_msg)
-        
-        self.game.katrain.log(f"[HumanStyleStrategy] Human policy found in analysis", OUTPUT_DEBUG)
+
+        self.game.katrain.log("[HumanStyleStrategy] Human policy found in analysis", OUTPUT_DEBUG)
         board_size = self.game.board_size
         self.game.katrain.log(f"[HumanStyleStrategy] Board size: {board_size}", OUTPUT_DEBUG)
         human_policy = analysis["humanPolicy"]
         self.game.katrain.log(f"[HumanStyleStrategy] Human policy length: {len(human_policy)}", OUTPUT_DEBUG)
         if len(human_policy) != 362:
-            self.game.katrain.log(f"[HumanStyleStrategy] WARNING: Human policy length {len(human_policy)} != 362", OUTPUT_ERROR)
-        
+            self.game.katrain.log(
+                f"[HumanStyleStrategy] WARNING: Human policy length {len(human_policy)} != 362", OUTPUT_ERROR
+            )
+
         # Create a list of moves with their human policy weights
         moves = []
         for x in range(board_size[0]):
@@ -1409,52 +1674,65 @@ class HumanStyleStrategy(AIStrategy):
                 idx = (board_size[1] - y - 1) * board_size[0] + x
                 if idx < len(human_policy) and human_policy[idx] > 0:
                     moves.append((Move((x, y), player=self.cn.next_player), human_policy[idx]))
-        
-        self.game.katrain.log(f"[HumanStyleStrategy] Generated {len(moves)} candidate moves from human policy", OUTPUT_DEBUG)
-                    
+
+        self.game.katrain.log(
+            f"[HumanStyleStrategy] Generated {len(moves)} candidate moves from human policy", OUTPUT_DEBUG
+        )
+
         # Add pass move if it has positive probability
         if len(human_policy) > board_size[0] * board_size[1] and human_policy[-1] > 0:
-            self.game.katrain.log(f"[HumanStyleStrategy] Adding pass move with probability {human_policy[-1]}", OUTPUT_DEBUG)
+            self.game.katrain.log(
+                f"[HumanStyleStrategy] Adding pass move with probability {human_policy[-1]}", OUTPUT_DEBUG
+            )
             moves.append((Move(None, player=self.cn.next_player), human_policy[-1]))
-            
-        self.game.katrain.log(f"[HumanStyleStrategy] Performing weighted selection from {len(moves)} moves", OUTPUT_DEBUG)
+
+        self.game.katrain.log(
+            f"[HumanStyleStrategy] Performing weighted selection from {len(moves)} moves", OUTPUT_DEBUG
+        )
         top_moves = sorted(moves, key=lambda x: -x[1])
-        self.game.katrain.log(f"[HumanStyleStrategy] Top 5 moves by probability:", OUTPUT_DEBUG)
-        
+        self.game.katrain.log("[HumanStyleStrategy] Top 5 moves by probability:", OUTPUT_DEBUG)
+
         # Create a formatted string of top 5 moves for ai_thoughts
-        top_moves_str = "\n".join([f"#{i+1}: {move.gtp()} - {prob:.1%}" for i, (move, prob) in enumerate(top_moves[:5])])
+        top_moves_str = "\n".join(
+            [f"#{i + 1}: {move.gtp()} - {prob:.1%}" for i, (move, prob) in enumerate(top_moves[:5])]
+        )
 
         self.game.katrain.log(f"[HumanStyleStrategy]\n{top_moves_str}", OUTPUT_DEBUG)
-        
+
         selected = weighted_selection_without_replacement(moves, 1)[0]
         move = selected[0]
         prob = selected[1]
-        
+
         # Find the rank of the selected move
-        selected_rank = next((i+1 for i, (m, _) in enumerate(top_moves) if m.gtp() == move.gtp()), "ERROR: move not found in ranking")
-        
-        self.game.katrain.log(f"[HumanStyleStrategy] Selected move {move.gtp()} with probability {prob:.4f}", OUTPUT_DEBUG)
+        selected_rank = next(
+            (i + 1 for i, (m, _) in enumerate(top_moves) if m.gtp() == move.gtp()), "ERROR: move not found in ranking"
+        )
+
+        self.game.katrain.log(
+            f"[HumanStyleStrategy] Selected move {move.gtp()} with probability {prob:.4f}", OUTPUT_DEBUG
+        )
         ai_thoughts = f"\n{top_moves_str}\n\nPlayed move {move.gtp()} ({prob:.1%}) as the #{selected_rank} top move."
         self.game.katrain.log(f"[HumanStyleStrategy] Final decision: {move.gtp()}", OUTPUT_DEBUG)
         return move, ai_thoughts
 
+
 def generate_ai_move(game: Game, ai_mode: str, ai_settings: Dict) -> Tuple[Move, GameNode]:
     """Generate a move using the selected AI strategy"""
     game.katrain.log(f"Generate AI move called with mode: {ai_mode}", OUTPUT_DEBUG)
-    
+
     # Create the appropriate strategy based on mode
 
     strategy = STRATEGY_REGISTRY[ai_mode](game, ai_settings)
-    
+
     # Generate the move
     game.katrain.log(f"Generating move using {strategy.__class__.__name__}", OUTPUT_DEBUG)
     move, ai_thoughts = strategy.generate_move()
-    
+
     # Play the move and return
     game.katrain.log(f"Playing move {move.gtp()} and creating game node", OUTPUT_DEBUG)
     played_node = game.play(move)
     game.katrain.log(f"AI thoughts: {ai_thoughts}", OUTPUT_DEBUG)
     played_node.ai_thoughts = ai_thoughts
-    
+
     game.katrain.log(f"Move generation complete: {move.gtp()}", OUTPUT_DEBUG)
     return move, played_node

--- a/katrain/core/base_katrain.py
+++ b/katrain/core/base_katrain.py
@@ -7,16 +7,16 @@ from kivy.storage.jsonstore import JsonStore
 
 from katrain.core.ai import ai_rank_estimation
 from katrain.core.constants import (
-    PLAYER_HUMAN,
-    PLAYER_AI,
-    PLAYING_NORMAL,
-    PLAYING_TEACHING,
-    OUTPUT_INFO,
-    OUTPUT_ERROR,
-    OUTPUT_DEBUG,
     AI_DEFAULT,
     CONFIG_MIN_VERSION,
     DATA_FOLDER,
+    OUTPUT_DEBUG,
+    OUTPUT_ERROR,
+    OUTPUT_INFO,
+    PLAYER_AI,
+    PLAYER_HUMAN,
+    PLAYING_NORMAL,
+    PLAYING_TEACHING,
 )
 from katrain.core.utils import find_package_resource
 
@@ -106,8 +106,11 @@ class KaTrainBase:
                         parent_dir = os.path.split(user_config_file)[0]
                         self.log(f"Creating parent directory if needed: {parent_dir}", OUTPUT_DEBUG)
                         os.makedirs(parent_dir, exist_ok=True)
-                        
-                        self.log(f"Copying package config {package_config_file} to user config {user_config_file}", OUTPUT_DEBUG)
+
+                        self.log(
+                            f"Copying package config {package_config_file} to user config {user_config_file}",
+                            OUTPUT_DEBUG,
+                        )
                         shutil.copyfile(package_config_file, user_config_file)
                         config_file = user_config_file
                         self.log(f"Copied package config to local file {config_file}", OUTPUT_INFO)
@@ -116,7 +119,7 @@ class KaTrainBase:
                             version_str = JsonStore(user_config_file).get("general")["version"]
                             version = parse_version(version_str)
                             self.log(f"Parsed version: {version}", OUTPUT_DEBUG)
-                        except Exception as e:  # noqa E722 broken file etc
+                        except Exception as e:  # broken file etc
                             self.log(f"Failed to read version from user config: {e}", OUTPUT_DEBUG)
                             version_str = "0.0.0"
                             version = [0, 0, 0]

--- a/katrain/core/constants.py
+++ b/katrain/core/constants.py
@@ -96,12 +96,12 @@ AI_STRENGTH = {  # dan ranks, backup if model is missing. TODO: remove some?
     AI_SIMPLE_OWNERSHIP: 2,
     AI_SETTLE_STONES: 2,
     AI_HUMAN: float("nan"),
-    AI_PRO: float("nan")
+    AI_PRO: float("nan"),
 }
 
 AI_OPTION_VALUES = {
     "kyu_rank": [(k, f"{k}[strength:kyu]") for k in range(15, 0, -1)]
-    + [(k, f"{1-k}[strength:dan]") for k in range(0, -3, -1)],
+    + [(k, f"{1 - k}[strength:dan]") for k in range(0, -3, -1)],
     "strength": [0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.4, 0.5, 1],
     "opening_moves": range(0, 51),
     "pick_override": [0, 0.5, 0.6, 0.7, 0.8, 0.85, 0.9, 0.95, 0.99, 1],
@@ -114,17 +114,17 @@ AI_OPTION_VALUES = {
     "line_weight": range(0, 11),
     "threshold": [2, 2.5, 3, 3.5, 4, 4.5],
     "automatic": "bool",
-    "pda": [(x / 10, f"{'W' if x<0 else 'B'}+{abs(x/10):.1f}") for x in range(-30, 31)],
+    "pda": [(x / 10, f"{'W' if x < 0 else 'B'}+{abs(x / 10):.1f}") for x in range(-30, 31)],
     "max_points_lost": [x / 10 for x in range(51)],
     "settled_weight": [x / 4 for x in range(0, 17)],
     "opponent_fac": [x / 10 for x in range(-20, 11)],
     "min_visits": range(1, 10),
     "attach_penalty": [x / 10 for x in range(-10, 51)],
     "tenuki_penalty": [x / 10 for x in range(-10, 51)],
-    "human_kyu_rank": [(k, f"{k}[strength:kyu]") for k in range(20, 0, -1)] +
-                  [(k, f"{1-k}[strength:dan]") for k in range(0, -9,-1)],
+    "human_kyu_rank": [(k, f"{k}[strength:kyu]") for k in range(20, 0, -1)]
+    + [(k, f"{1 - k}[strength:dan]") for k in range(0, -9, -1)],
     "modern_style": "bool",
-    "pro_year": range(1800,2024),
+    "pro_year": range(1800, 2024),
 }
 
 AI_KEY_PROPERTIES = {

--- a/katrain/core/contribute_engine.py
+++ b/katrain/core/contribute_engine.py
@@ -1,16 +1,14 @@
 import json
 import os
-import random
 import shlex
 import shutil
-import signal
 import subprocess
 import threading
 import time
 import traceback
 from collections import defaultdict
 
-from katrain.core.constants import OUTPUT_DEBUG, OUTPUT_ERROR, OUTPUT_INFO, OUTPUT_KATAGO_STDERR, DATA_FOLDER
+from katrain.core.constants import DATA_FOLDER, OUTPUT_DEBUG, OUTPUT_ERROR, OUTPUT_INFO, OUTPUT_KATAGO_STDERR
 from katrain.core.engine import BaseEngine
 from katrain.core.game import BaseGame
 from katrain.core.lang import i18n
@@ -129,7 +127,7 @@ class KataGoContributeEngine(BaseEngine):
                 self.katrain("update-state", redraw_board=True)
 
     def status(self):
-        return f"Contributing to distributed training\nGames: {self.uploaded_games_count} uploaded, {len(self.active_games)} in buffer, {len(self.finished_games)} shown\n{self.move_count} moves played ({60*self.move_count/(time.time()-self.start_time):.1f}/min, {self.visits_count / (time.time() - self.start_time):.1f} visits/s)\n"
+        return f"Contributing to distributed training\nGames: {self.uploaded_games_count} uploaded, {len(self.active_games)} in buffer, {len(self.finished_games)} shown\n{self.move_count} moves played ({60 * self.move_count / (time.time() - self.start_time):.1f}/min, {self.visits_count / (time.time() - self.start_time):.1f} visits/s)\n"
 
     def is_idle(self):
         return False
@@ -284,7 +282,7 @@ class KataGoContributeEngine(BaseEngine):
                                 self.last_move_for_game[game_id] = time.time()
                                 dt = self.last_move_for_game[game_id] - last_move if last_move else 0
                                 self.katrain.log(
-                                    f"[{time.time()-self.start_time:.1f}] Game {game_id} Move {analysis['turnNumber']}: {' '.join(analysis['move'])} Visits {analysis['rootInfo']['visits']} Time {dt:.1f}s\t Moves/min {60*self.move_count/(time.time()-self.start_time):.1f} Visits/s {self.visits_count/(time.time()-self.start_time):.1f}",
+                                    f"[{time.time() - self.start_time:.1f}] Game {game_id} Move {analysis['turnNumber']}: {' '.join(analysis['move'])} Visits {analysis['rootInfo']['visits']} Time {dt:.1f}s\t Moves/min {60 * self.move_count / (time.time() - self.start_time):.1f} Visits/s {self.visits_count / (time.time() - self.start_time):.1f}",
                                     OUTPUT_DEBUG,
                                 )
                                 self.katrain("update-state")

--- a/katrain/core/engine.py
+++ b/katrain/core/engine.py
@@ -13,12 +13,12 @@ from typing import Callable, Dict, List, Optional
 from kivy.utils import platform as kivy_platform
 
 from katrain.core.constants import (
+    DATA_FOLDER,
+    KATAGO_EXCEPTION,
     OUTPUT_DEBUG,
     OUTPUT_ERROR,
     OUTPUT_EXTRA_DEBUG,
     OUTPUT_KATAGO_STDERR,
-    DATA_FOLDER,
-    KATAGO_EXCEPTION,
     PONDERING_REPORT_DT,
 )
 from katrain.core.game_node import GameNode
@@ -47,7 +47,6 @@ def resolve_engine_backend(config) -> str:
 
 
 class BaseEngine:  # some common elements between analysis and contribute engine
-
     RULESETS_ABBR = [
         ("jp", "japanese"),
         ("cn", "chinese"),
@@ -139,13 +138,13 @@ class KataGoEngine(BaseEngine):
             model = find_package_resource(config["model"])
             cfg = find_package_resource(config["config"])
             exe = self.get_engine_path(config.get("katago", "").strip())
-            
+
             if not exe:
                 return
-                
+
             # Add human model to command if provided
             if config.get("humanlike_model", ""):
-                human_model_path = find_package_resource(config.get("humanlike_model",""))
+                human_model_path = find_package_resource(config.get("humanlike_model", ""))
                 if os.path.isfile(human_model_path):
                     self.command = shlex.split(
                         f'"{exe}" analysis -model "{model}" -human-model "{human_model_path}" -config "{cfg}" -override-config "homeDataDir={os.path.expanduser(DATA_FOLDER)}"'
@@ -337,7 +336,7 @@ class KataGoEngine(BaseEngine):
                     time_taken = time.time() - start_time
                     results_exist = not analysis.get("noResults", False)
                     self.katrain.log(
-                        f"[{time_taken:.1f}][{query_id}][{'....' if partial_result else 'done'}] KataGo analysis received: {len(analysis.get('moveInfos',[]))} candidate moves, {analysis['rootInfo']['visits'] if results_exist else 'n/a'} visits",
+                        f"[{time_taken:.1f}][{query_id}][{'....' if partial_result else 'done'}] KataGo analysis received: {len(analysis.get('moveInfos', []))} candidate moves, {analysis['rootInfo']['visits'] if results_exist else 'n/a'} visits",
                         OUTPUT_DEBUG,
                     )
                     self.katrain.log(json_truncate_arrays(analysis), OUTPUT_EXTRA_DEBUG)

--- a/katrain/core/game.py
+++ b/katrain/core/game.py
@@ -6,26 +6,24 @@ import threading
 from datetime import datetime
 from typing import Dict, List, Optional, Union
 
-from kivy.clock import Clock
-
 from katrain.core.constants import (
     OUTPUT_DEBUG,
     OUTPUT_EXTRA_DEBUG,
     OUTPUT_INFO,
     PLAYER_AI,
     PLAYER_HUMAN,
+    PRIORITY_ALTERNATIVES,
+    PRIORITY_DEFAULT,
+    PRIORITY_EQUALIZE,
+    PRIORITY_EXTRA_ANALYSIS,
+    PRIORITY_GAME_ANALYSIS,
+    PRIORITY_SWEEP,
     PROGRAM_NAME,
     SGF_INTERNAL_COMMENTS_MARKER,
     STATUS_ANALYSIS,
     STATUS_ERROR,
     STATUS_INFO,
     STATUS_TEACHING,
-    PRIORITY_GAME_ANALYSIS,
-    PRIORITY_EXTRA_ANALYSIS,
-    PRIORITY_SWEEP,
-    PRIORITY_ALTERNATIVES,
-    PRIORITY_EQUALIZE,
-    PRIORITY_DEFAULT,
 )
 from katrain.core.engine import KataGoEngine
 from katrain.core.game_node import GameNode
@@ -119,9 +117,7 @@ class BaseGame:
     # -- move tree functions --
     def _init_state(self):
         board_size_x, board_size_y = self.board_size
-        self.board = [
-            [-1 for _x in range(board_size_x)] for _y in range(board_size_y)
-        ]  # type: List[List[int]]  #  board pos -> chain id
+        self.board = [[-1 for _x in range(board_size_x)] for _y in range(board_size_y)]  # type: List[List[int]]  #  board pos -> chain id
         self.chains = []  # type: List[List[Move]]  #   chain id -> chain
         self.prisoners = []  # type: List[Move]
         self.last_capture = []  # type: List[Move]
@@ -615,7 +611,7 @@ class Game(BaseGame):
                 max_point_loss = max(c.points_lost or 0 for c in [node] + node.children)
                 if only_mistakes and max_point_loss <= threshold:
                     continue
-                if move_range and (not node.depth - 1 in range(move_range[0], move_range[1] + 1)):
+                if move_range and (node.depth - 1 not in range(move_range[0], move_range[1] + 1)):
                     continue
                 node.analyze(engine, visits=visits, priority=-1_000_000, time_limit=False, report_every=None)
             if not move_range:
@@ -738,7 +734,7 @@ class Game(BaseGame):
                 else:  # we're a bit lost, far away from target, just push it closer
                     move_info = min(candidates, key=lambda move: abs(move["scoreLead"] - target_score))
                     self.katrain.log(
-                        f"* Played {move_info['move']} {move_info['scoreLead']} because score deviation between current score {node.score} and target score {target_score} > {3*stddev}",
+                        f"* Played {move_info['move']} {move_info['scoreLead']} because score deviation between current score {node.score} and target score {target_score} > {3 * stddev}",
                         OUTPUT_EXTRA_DEBUG,
                     )
                     ai_thoughts += f"Move played to close difference between score {node.score:.1f} and target {target_score:.1f} quickly."

--- a/katrain/core/game_node.py
+++ b/katrain/core/game_node.py
@@ -6,14 +6,14 @@ import random
 from typing import Dict, List, Optional, Tuple
 
 from katrain.core.constants import (
+    ADDITIONAL_MOVE_ORDER,
     ANALYSIS_FORMAT_VERSION,
+    PRIORITY_DEFAULT,
     PROGRAM_NAME,
     REPORT_DT,
     SGF_INTERNAL_COMMENTS_MARKER,
     SGF_SEPARATOR_MARKER,
     VERSION,
-    PRIORITY_DEFAULT,
-    ADDITIONAL_MOVE_ORDER,
 )
 from katrain.core.lang import i18n
 from katrain.core.sgf_parser import Move, SGFNode
@@ -292,7 +292,7 @@ class GameNode(SGFNode):
     def format_score(self, score=None):
         score = score or self.score
         if score is not None:
-            leading_player = 'B' if score >= 0 else 'W'
+            leading_player = "B" if score >= 0 else "W"
             leading_player_color = i18n._(f"short color {leading_player}")
             return f"{leading_player_color}+{abs(score):.1f}"
 
@@ -304,9 +304,9 @@ class GameNode(SGFNode):
     def format_winrate(self, win_rate=None):
         win_rate = win_rate or self.winrate
         if win_rate is not None:
-            leading_player = 'B' if win_rate > 0.5 else 'W'
+            leading_player = "B" if win_rate > 0.5 else "W"
             leading_player_color = i18n._(f"short color {leading_player}")
-            return f"{leading_player_color} {max(win_rate,1-win_rate):.1%}"
+            return f"{leading_player_color} {max(win_rate, 1 - win_rate):.1%}"
 
     def move_policy_stats(self) -> Tuple[Optional[int], float, List]:
         single_move = self.move

--- a/katrain/core/lang.py
+++ b/katrain/core/lang.py
@@ -86,4 +86,4 @@ def rank_label(rank):
     if rank >= 0.5:
         return f"{rank:.0f}{i18n._('strength:dan')}"
     else:
-        return f"{1-rank:.0f}{i18n._('strength:kyu')}"
+        return f"{1 - rank:.0f}{i18n._('strength:kyu')}"

--- a/katrain/core/sgf_parser.py
+++ b/katrain/core/sgf_parser.py
@@ -1,9 +1,10 @@
 import copy
-import chardet
 import math
 import re
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Tuple
+
+import chardet
 
 
 class ParseError(Exception):
@@ -492,7 +493,7 @@ class SGF:
                 values = re.split(r"\]\s*\[", value)
                 current_move.add_list_property(property, [SGFNode._unescape_value(v) for v in values])
         if self.ix < len(self.contents):
-            raise ParseError(f"Parse Error: unexpected character at {self.contents[self.ix:self.ix+25]}")
+            raise ParseError(f"Parse Error: unexpected character at {self.contents[self.ix : self.ix + 25]}")
         raise ParseError("Parse Error: expected ')' at end of input.")
 
     # NGF parser adapted from https://github.com/fohristiwhirl/gofish/
@@ -571,7 +572,6 @@ class SGF:
             if len(line) >= 7:
                 if line[0:2] == "PM":
                     if line[4] in ["B", "W"]:
-
                         # move format is similar to SGF, but uppercase and out-by-1
 
                         key = line[4]
@@ -617,7 +617,7 @@ class SGF:
             try:
                 grlt = int(re.search(grlt_regex, line).group(1))
                 zipsu = int(re.search(zipsu_regex, line).group(1))
-            except:  # noqa E722
+            except:  # noqa: E722
                 return ""
             return gib_make_result(grlt, zipsu)
 
@@ -651,7 +651,7 @@ class SGF:
                         komi = int(re.search(r"GONGJE:(\d+),", line).group(1)) / 10
                         if komi:
                             root.set_property("KM", komi)
-                    except:  # noqa E722
+                    except:  # noqa: E722
                         pass
 
             if line.startswith("\\[GAMETAG="):
@@ -660,7 +660,7 @@ class SGF:
                         match = re.search(r"C(\d\d\d\d):(\d\d):(\d\d)", line)
                         date = "{}-{}-{}".format(match.group(1), match.group(2), match.group(3))
                         root.set_property("DT", date)
-                    except:  # noqa E722
+                    except:  # noqa: E722
                         pass
 
                 if "RE" not in root.properties:
@@ -673,7 +673,7 @@ class SGF:
                         komi = int(re.search(r",G(\d+),", line).group(1)) / 10
                         if komi:
                             root.set_property("KM", komi)
-                    except:  # noqa E722
+                    except:  # noqa: E722
                         pass
 
             if line[0:3] == "INI":

--- a/katrain/core/utils.py
+++ b/katrain/core/utils.py
@@ -1,13 +1,11 @@
 import heapq
+import importlib.resources as pkg_resources
 import math
-from pathlib import Path
 import random
 import struct
 import sys
+from pathlib import Path
 from typing import List, Tuple, TypeVar
-
-import importlib.resources as pkg_resources
-
 
 T = TypeVar("T")
 
@@ -72,10 +70,10 @@ def format_visits(n):
     if n < 1000:
         return str(n)
     if n < 1e5:
-        return f"{n/1000:.1f}k"
+        return f"{n / 1000:.1f}k"
     if n < 1e6:
-        return f"{n/1000:.0f}k"
-    return f"{n/1e6:.0f}M"
+        return f"{n / 1000:.0f}k"
+    return f"{n / 1e6:.0f}M"
 
 
 def json_truncate_arrays(data, lim=20):

--- a/katrain/gui/badukpan.py
+++ b/katrain/gui/badukpan.py
@@ -1,12 +1,12 @@
+import copy
 import math
 import time
 from typing import List, Optional
-import copy
 
 from kivy.clock import Clock
 from kivy.core.window import Window
+from kivy.graphics.context_instructions import Color, PopMatrix, PushMatrix, Rotate, Translate
 from kivy.graphics.texture import Texture
-from kivy.graphics.context_instructions import Color, Rotate, Translate, PushMatrix, PopMatrix
 from kivy.graphics.vertex_instructions import Ellipse, Line, Rectangle
 from kivy.metrics import dp
 from kivy.properties import BooleanProperty, ListProperty, NumericProperty, ObjectProperty
@@ -31,9 +31,9 @@ from katrain.core.constants import (
 )
 from katrain.core.game import Move
 from katrain.core.lang import i18n
-from katrain.core.utils import evaluation_class, format_visits, var_to_grid, json_truncate_arrays
-from katrain.gui.kivyutils import draw_circle, draw_text, cached_texture
-from katrain.gui.popups import I18NPopup, ReAnalyzeGamePopup, GameReportPopup, TsumegoFramePopup
+from katrain.core.utils import evaluation_class, format_visits, json_truncate_arrays, var_to_grid
+from katrain.gui.kivyutils import cached_texture, draw_circle, draw_text
+from katrain.gui.popups import GameReportPopup, I18NPopup, ReAnalyzeGamePopup, TsumegoFramePopup
 from katrain.gui.theme import Theme
 
 
@@ -204,14 +204,14 @@ class BadukPanWidget(Widget):
                     katrain.update_state()
                 else:  # load comments & pv
                     katrain.log(
-                        f"\nAnalysis:\n{json_truncate_arrays(nodes_here[-1].analysis,lim=5)}", OUTPUT_EXTRA_DEBUG
+                        f"\nAnalysis:\n{json_truncate_arrays(nodes_here[-1].analysis, lim=5)}", OUTPUT_EXTRA_DEBUG
                     )
                     katrain.log(
-                        f"\nParent Analysis:\n{json_truncate_arrays(nodes_here[-1].parent.analysis,lim=5)}",
+                        f"\nParent Analysis:\n{json_truncate_arrays(nodes_here[-1].parent.analysis, lim=5)}",
                         OUTPUT_EXTRA_DEBUG,
                     )
                     katrain.log(
-                        f"\nRoot Stats:\n{json_truncate_arrays(nodes_here[-1].analysis['root'],lim=5)}", OUTPUT_DEBUG
+                        f"\nRoot Stats:\n{json_truncate_arrays(nodes_here[-1].analysis['root'], lim=5)}", OUTPUT_DEBUG
                     )
                     katrain.controls.info.text = nodes_here[-1].comment(sgf=True)
                     katrain.controls.active_comment_node = nodes_here[-1]
@@ -589,7 +589,6 @@ class BadukPanWidget(Widget):
         if self.rotation_degree == 90:
             y_text = Move.GTP_COORD[board_size_y - i - 1]
         elif self.rotation_degree == 180:
-
             y_text = str(board_size_y - i)
         elif self.rotation_degree == 270:
             y_text = Move.GTP_COORD[i]
@@ -736,7 +735,7 @@ class BadukPanWidget(Widget):
                             Color(*Theme.HINT_TEXT_COLOR)
                             draw_text(
                                 pos=(self.gridpos[y][x][0], self.gridpos[y][x][1]),
-                                text=f"{100 * move_policy :.2f}"[:4] + "%",
+                                text=f"{100 * move_policy:.2f}"[:4] + "%",
                                 font_name="Roboto",
                                 font_size=self.grid_size / 4,
                                 halign="center",
@@ -943,7 +942,7 @@ class BadukPanWidget(Widget):
                         if (
                             move_dict["visits"] < low_visits_threshold
                             and not engine_best_move
-                            and not move_dict["move"] in child_moves
+                            and move_dict["move"] not in child_moves
                         ):
                             scale = Theme.UNCERTAIN_HINT_SCALE
                             text_on = False
@@ -997,7 +996,7 @@ class BadukPanWidget(Widget):
 
                             keys[TOP_MOVE_SCORE] = f"{player_sign * move_dict['scoreLead']:.1f}"
                             winrate = move_dict["winrate"] if player_sign == 1 else 1 - move_dict["winrate"]
-                            keys[TOP_MOVE_WINRATE] = f"{winrate*100:.1f}"
+                            keys[TOP_MOVE_WINRATE] = f"{winrate * 100:.1f}"
                             keys[TOP_MOVE_DELTA_WINRATE] = f"{-move_dict['winrateLost']:+.1%}"
                             keys[TOP_MOVE_VISITS] = format_visits(move_dict["visits"])
 

--- a/katrain/gui/controlspanel.py
+++ b/katrain/gui/controlspanel.py
@@ -6,18 +6,18 @@ from kivy.uix.boxlayout import BoxLayout
 from kivymd.uix.floatlayout import MDFloatLayout
 
 from katrain.core.constants import (
+    AI_DEFAULT,
     MODE_ANALYZE,
     MODE_PLAY,
+    PLAYER_AI,
     PLAYER_HUMAN,
     STATUS_ANALYSIS,
     STATUS_ERROR,
-    AI_DEFAULT,
-    PLAYER_AI,
 )
 from katrain.core.lang import rank_label
 from katrain.gui.kivyutils import AnalysisToggle, CollapsablePanel
-from katrain.gui.theme import Theme
 from katrain.gui.sound import play_sound, stop_sound
+from katrain.gui.theme import Theme
 
 
 class PlayAnalyzeSelect(MDFloatLayout):

--- a/katrain/gui/kivyutils.py
+++ b/katrain/gui/kivyutils.py
@@ -25,7 +25,6 @@ from kivymd.uix.behaviors import CircularRippleBehavior, RectangularRippleBehavi
 from kivymd.uix.boxlayout import MDBoxLayout
 from kivymd.uix.button import BaseFlatButton, BasePressedButton
 from kivymd.uix.navigationdrawer import MDNavigationDrawer
-from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.textfield import MDTextField
 
 from katrain.core.constants import (

--- a/katrain/gui/popups.py
+++ b/katrain/gui/popups.py
@@ -24,7 +24,6 @@ from kivymd.uix.selectioncontrol import MDCheckbox
 from kivymd.uix.textfield import MDTextField
 
 from katrain.core.ai import ai_rank_estimation, game_report
-from katrain.core.engine import resolve_engine_backend
 from katrain.core.constants import (
     AI_CONFIG_DEFAULT,
     AI_DEFAULT,
@@ -35,24 +34,19 @@ from katrain.core.constants import (
     OUTPUT_DEBUG,
     OUTPUT_ERROR,
     OUTPUT_INFO,
-    SGF_INTERNAL_COMMENTS_MARKER,
-    STATUS_INFO,
     PLAYER_HUMAN,
-    ADDITIONAL_MOVE_ORDER,
+    SGF_INTERNAL_COMMENTS_MARKER,
 )
+from katrain.core.engine import resolve_engine_backend
 from katrain.core.lang import i18n, rank_label
 from katrain.core.sgf_parser import Move
-from katrain.core.utils import PATHS, find_package_resource, evaluation_class
+from katrain.core.utils import PATHS, find_package_resource
 from katrain.gui.kivyutils import (
     BackgroundMixin,
     I18NSpinner,
-    BackgroundLabel,
-    TableHeaderLabel,
     TableCellLabel,
+    TableHeaderLabel,
     TableStatLabel,
-    PlayerInfo,
-    SizedRectangleButton,
-    AutoSizedRectangleButton,
 )
 from katrain.gui.theme import Theme
 from katrain.gui.widgets.progress_loader import ProgressLoader
@@ -429,7 +423,7 @@ class ConfigAIPopup(QuickConfigGui):
                     widget.bind(active=self.estimate_rank_from_options)
                 else:
                     if isinstance(values[0], Tuple):  # with descriptions, possibly language-specific
-                        fixed_values = [(v, re.sub(r"\[(.*?)]", lambda m: i18n._(m[1]), l)) for v, l in values]
+                        fixed_values = [(v, re.sub(r"\[(.*?)]", lambda m: i18n._(m[1]), text)) for v, text in values]
                     else:  # just numbers
                         fixed_values = [(v, str(v)) for v in values]
                     widget = LabelledSelectionSlider(
@@ -744,7 +738,7 @@ class BaseConfigPopup(QuickConfigGui):
                                 try:
                                     with open(os.path.join(os.path.split(path)[0], f), "wb") as fout:
                                         fout.write(zipObj.read(f))
-                                except:  # already there? no problem
+                                except:  # noqa: E722 -- already there? no problem
                                     pass
                     os.remove(tmp_path)
                 else:
@@ -948,7 +942,7 @@ class GameReportPopup(BoxLayout):
         table.add_widget(TableHeaderLabel(text=i18n._("header:keystats"), background_color=Theme.BACKGROUND_COLOR))
         table.add_widget(TableHeaderLabel(text="", background_color=Theme.BACKGROUND_COLOR))
 
-        for i, (label, fmt, stat, scale, more_is_better) in enumerate(
+        for i, (label, fmt, stat_key, scale, more_is_better) in enumerate(
             [
                 ("accuracy", "{:.1f}", "accuracy", 100, True),
                 ("meanpointloss", "{:.2f}", "mean_ptloss", 5, False),
@@ -958,13 +952,13 @@ class GameReportPopup(BoxLayout):
         ):
             statcell = {
                 bw: TableStatLabel(
-                    text=fmt.format(sum_stats[bw][stat]) if stat in sum_stats[bw] else "",
+                    text=fmt.format(sum_stats[bw][stat_key]) if stat_key in sum_stats[bw] else "",
                     side=side,
-                    value=sum_stats[bw].get(stat, 0),
+                    value=sum_stats[bw].get(stat_key, 0),
                     scale=scale,
                     bar_color=(
                         Theme.STAT_BETTER_COLOR
-                        if (sum_stats[bw].get(stat, 0) < sum_stats[Move.opponent_player(bw)].get(stat, 0))
+                        if (sum_stats[bw].get(stat_key, 0) < sum_stats[Move.opponent_player(bw)].get(stat_key, 0))
                         ^ more_is_better
                         else Theme.STAT_WORSE_COLOR
                     ),

--- a/katrain/gui/sound.py
+++ b/katrain/gui/sound.py
@@ -1,4 +1,3 @@
-from kivy.clock import Clock
 from kivy.core.audio import SoundLoader
 from kivy.utils import platform
 
@@ -21,13 +20,10 @@ def preload_sounds(sound_dir):
     """
     global _audio_available
     import os
-    import sys
     import subprocess
+    import sys
 
-    audio_files = [
-        os.path.join(sound_dir, fn) for fn in os.listdir(sound_dir)
-        if fn.endswith((".wav", ".ogg", ".mp3"))
-    ]
+    audio_files = [os.path.join(sound_dir, fn) for fn in os.listdir(sound_dir) if fn.endswith((".wav", ".ogg", ".mp3"))]
     if not audio_files:
         return
 
@@ -41,9 +37,13 @@ def preload_sounds(sound_dir):
     if platform != "win" and not getattr(sys, "frozen", False):
         try:
             subprocess.run(
-                [sys.executable, "-c",
-                 f"from kivy.core.audio import SoundLoader; SoundLoader.load({audio_files[0]!r})"],
-                timeout=3, capture_output=True,
+                [
+                    sys.executable,
+                    "-c",
+                    f"from kivy.core.audio import SoundLoader; SoundLoader.load({audio_files[0]!r})",
+                ],
+                timeout=3,
+                capture_output=True,
             )
         except subprocess.TimeoutExpired as e:
             print(f"Warning: Audio unavailable ({e}). Sounds disabled.", file=sys.stderr)
@@ -63,6 +63,7 @@ def play_sound(file, volume=1, cache=True):
     # is no sound device, it deadlocks. We delay the import until we know audio
     # is available
     from kivymd.app import MDApp
+
     app = MDApp.get_running_app()
     if app and app.gui and app.gui.config("timer/sound"):
         sound = cached_sounds.get(file)

--- a/katrain/gui/widgets/filebrowser.py
+++ b/katrain/gui/widgets/filebrowser.py
@@ -37,6 +37,7 @@ a shortcut to the Documents directory added to the favorites bar::
 .. image:: _static/filebrowser.png
     :align: right
 """
+
 import string
 from functools import partial
 from os import walk
@@ -54,7 +55,7 @@ from kivy.utils import platform
 from katrain.gui.theme import Theme
 
 if platform == "win":
-    from ctypes import windll, create_unicode_buffer
+    from ctypes import create_unicode_buffer, windll
 
 
 def last_modified_first(files, filesystem):

--- a/katrain/gui/widgets/graph.py
+++ b/katrain/gui/widgets/graph.py
@@ -122,13 +122,9 @@ class ScoreGraph(Graph):
             # Point loss: both players' losses go upward from zero
             # (avoids oscillation that would occur if one player went up and other went down)
             pointloss_values = [
-                max(0, n.points_lost) if n and n.move and n.points_lost is not None else math.nan
-                for n in nodes
+                max(0, n.points_lost) if n and n.move and n.points_lost is not None else math.nan for n in nodes
             ]
-            pointloss_nn_values = [
-                max(0, n.points_lost)
-                for n in nodes if n and n.move and n.points_lost is not None
-            ]
+            pointloss_nn_values = [max(0, n.points_lost) for n in nodes if n and n.move and n.points_lost is not None]
             pointloss_values_range = 0, max(pointloss_nn_values or [0])
 
             score_granularity = 5
@@ -143,9 +139,9 @@ class ScoreGraph(Graph):
             )
             # Point loss scale: based on max loss, minimum of 5
             pointloss_granularity = 5
-            self.pointloss_scale = max(
-                math.ceil(pointloss_values_range[1] / pointloss_granularity), 1
-            ) * pointloss_granularity
+            self.pointloss_scale = (
+                max(math.ceil(pointloss_values_range[1] / pointloss_granularity), 1) * pointloss_granularity
+            )
 
             xscale = self.width / max(len(score_values) - 1, 15)
             available_height = self.height
@@ -159,7 +155,10 @@ class ScoreGraph(Graph):
             ]
             # Point loss: line from bottom going up (0 at bottom, max at top)
             pointloss_line_points = [
-                [self.x + i * xscale, self.y + available_height * (val / self.pointloss_scale) if not math.isnan(val) else math.nan]
+                [
+                    self.x + i * xscale,
+                    self.y + available_height * (val / self.pointloss_scale) if not math.isnan(val) else math.nan,
+                ]
                 for i, val in enumerate(pointloss_values)
             ]
             self.score_points = sum(score_line_points, [])
@@ -187,8 +186,8 @@ class ScoreGraph(Graph):
                 self.winrate_dot_pos = winrate_dot_point
                 if math.isnan(pointloss_dot_point[1]):
                     # Fall back to last known value, positioned from bottom
-                    pointloss_dot_point[1] = (
-                        self.y + available_height * ((pointloss_nn_values or [0])[-1] / self.pointloss_scale)
+                    pointloss_dot_point[1] = self.y + available_height * (
+                        (pointloss_nn_values or [0])[-1] / self.pointloss_scale
                     )
                 self.pointloss_dot_pos = pointloss_dot_point
 

--- a/katrain/gui/widgets/selection_slider.py
+++ b/katrain/gui/widgets/selection_slider.py
@@ -37,7 +37,7 @@ class SelectionSlider(Widget):
 
     def set_value(self, set_value):  # set to closest value
         if isinstance(set_value, (float, int)):
-            eq_value = sorted([(abs(v - set_value), i) for i, (v, l) in enumerate(self.values)])
+            eq_value = sorted([(abs(v - set_value), i) for i, (v, _label) in enumerate(self.values)])
             self.index = eq_value[0][1]
 
     def set_from_pos(self, pos):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,10 @@ katrain = "katrain.__main__:run_app"
 
 [dependency-groups]
 dev = [
-    "black>=26.3.1",
     "polib>=1.2.0,<2",
     "pyinstaller>=6.14.1",
     "pytest>=8.3.2",
+    "ruff>=0.15.8",
     "tomli>=1.2.0 ; python_version < '3.11'",
 ]
 
@@ -50,8 +50,19 @@ default-groups = [
     "dev",
 ]
 
-[tool.black]
+[tool.ruff]
 line-length = 120
+# Pinned to the minimum supported version so the CI matrix (3.10/3.12/3.13) is consistent.
+target-version = "py310"
+
+[tool.ruff.lint]
+# Carries over the policy the (previously unenforced) .flake8 described: pyflakes plus
+# the pycodestyle error subsets, with E501 left to the formatter. Adds import sorting,
+# and RUF100 so a stale or malformed `# noqa` cannot silently blanket-suppress a line.
+select = ["E4", "E7", "E9", "F", "I", "RUF100"]
+# Kivy's config has to be set before kivy submodules are imported, so module-level
+# imports legitimately appear after code in the GUI entry points.
+ignore = ["E402"]
 
 [tool.hatch.build.targets.sdist]
 include = ["katrain"]

--- a/spec/file_version.py
+++ b/spec/file_version.py
@@ -1,12 +1,12 @@
 # -*- mode: python ; coding: utf-8 -*-
-from PyInstaller.utils.win32 import versioninfo as ver
 import os
+
+from PyInstaller.utils.win32 import versioninfo as ver
 
 # only create VSVersionInfo object on Windows
 versionInfo = None
 
 if os.name == "nt":
-
     # load constants.py to get version number and program name
     import katrain.core.constants as constants
 

--- a/spec/hook-kivymd.py
+++ b/spec/hook-kivymd.py
@@ -1,55 +1,55 @@
-from PyInstaller.utils.hooks import collect_data_files, get_package_paths
 import os
 
+from PyInstaller.utils.hooks import collect_data_files, get_package_paths
+
 # Collect all KivyMD data files
-datas = collect_data_files('kivymd')
+datas = collect_data_files("kivymd")
 
 # Add specific KivyMD paths
-kivymd_path = get_package_paths('kivymd')[1]
+kivymd_path = get_package_paths("kivymd")[1]
 
 # Ensure KivyMD directories are included
-kivymd_data_dirs = ['fonts', 'images', 'uix']
+kivymd_data_dirs = ["fonts", "images", "uix"]
 for data_dir in kivymd_data_dirs:
     dir_path = os.path.join(kivymd_path, data_dir)
     if os.path.exists(dir_path):
-        datas.append((dir_path, f'kivymd/{data_dir}'))
+        datas.append((dir_path, f"kivymd/{data_dir}"))
 
 # Create missing .kv files for KivyMD components
 # This is a workaround for KivyMD 1.2.0 missing .kv files
 missing_kv_files = {
-    'kivymd/uix/label/label.kv': '''
+    "kivymd/uix/label/label.kv": """
 <MDLabel>:
     disabled_color: self.theme_cls.disabled_hint_text_color
     text_size: self.size
-''',
-    'kivymd/uix/button/button.kv': '''
+""",
+    "kivymd/uix/button/button.kv": """
 <MDButton>:
     disabled_color: self.theme_cls.disabled_hint_text_color
-''',
-    'kivymd/uix/textfield/textfield.kv': '''
+""",
+    "kivymd/uix/textfield/textfield.kv": """
 <MDTextField>:
     disabled_color: self.theme_cls.disabled_hint_text_color
-''',
+""",
 }
 
 # Add the missing .kv files to datas
 import tempfile
-import shutil
 
 temp_dir = tempfile.mkdtemp()
 for kv_path, kv_content in missing_kv_files.items():
     full_temp_path = os.path.join(temp_dir, kv_path)
     os.makedirs(os.path.dirname(full_temp_path), exist_ok=True)
-    with open(full_temp_path, 'w') as f:
+    with open(full_temp_path, "w") as f:
         f.write(kv_content)
     datas.append((full_temp_path, kv_path))
 
 # Hidden imports for KivyMD
 hiddenimports = [
-    'kivymd.icon_definitions',
-    'kivymd.font_definitions',
-    'kivymd.color_definitions',
-    'kivymd.uix.label.label',
-    'kivymd.uix.button.button',
-    'kivymd.uix.textfield.textfield',
-] 
+    "kivymd.icon_definitions",
+    "kivymd.font_definitions",
+    "kivymd.color_definitions",
+    "kivymd.uix.label.label",
+    "kivymd.uix.button.button",
+    "kivymd.uix.textfield.textfield",
+]

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -4,7 +4,7 @@ import pytest
 
 from katrain.core.ai import ai_rank_estimation, generate_ai_move
 from katrain.core.base_katrain import KaTrainBase
-from katrain.core.constants import AI_STRATEGIES, AI_STRATEGIES_RECOMMENDED_ORDER, AI_HUMAN, AI_PRO, OUTPUT_INFO
+from katrain.core.constants import AI_HUMAN, AI_PRO, AI_STRATEGIES, AI_STRATEGIES_RECOMMENDED_ORDER, OUTPUT_INFO
 from katrain.core.engine import KataGoEngine
 from katrain.core.game import Game
 

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -2,7 +2,7 @@ import pytest
 
 from katrain.core.base_katrain import KaTrainBase
 from katrain.core.engine import BaseEngine
-from katrain.core.game import Game, IllegalMoveException, Move, KaTrainSGF
+from katrain.core.game import Game, IllegalMoveException, KaTrainSGF, Move
 from katrain.core.game_node import GameNode
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -13,16 +13,16 @@ def test_version_consistency():
     # Get the project root directory (parent of tests directory)
     project_root = Path(__file__).parent.parent
     pyproject_path = project_root / "pyproject.toml"
-    
+
     # Read the version from pyproject.toml
     with open(pyproject_path, "rb") as f:
         pyproject_data = tomllib.load(f)
-    
+
     pyproject_version = pyproject_data["project"]["version"]
-    
+
     # Compare versions
     assert VERSION == pyproject_version, (
         f"Version mismatch: constants.py has '{VERSION}' but "
         f"pyproject.toml has '{pyproject_version}'. "
         "Please update both files to have the same version."
-    ) 
+    )


### PR DESCRIPTION
Consolidates formatting and linting onto ruff, replacing black and adding import sorting.

**Targets `master` and carries no version bump.** Tooling only — no runtime behavior changes. The bug fixes for the next version stack on top, in #840.

## First, a correction to the review's rationale

The review suggested ruff because it "would have flagged findings #1 and #6 statically." I tested that claim before acting on it, and it doesn't hold:

- **#1, the dead `except ParseError`** — no ruff rule catches this, verified against a reduced repro under `--select ALL`.
- **#6, the bare `except:`** — E722 does fire, but every one of those lines carried `# noqa E722`, so ruff would have stayed silent.

So this is worth doing, but not for the stated reason. Please don't merge it expecting it would have prevented those bugs.

## What actually argues for it

`.flake8` existed while flake8 was **not a dependency, not in CI, and not in pre-commit** — a lint policy the repo described but never ran. This deletes that file and carries its intent into `[tool.ruff.lint]`, where it's actually enforced.

Rules: `E4`/`E7`/`E9` + `F` (what the old `.flake8` implied, with E501 left to the formatter), plus `I` for import sorting and `RUF100` for stale noqa directives. `E402` stays ignored, since Kivy's config must be set before its submodules are imported.

**`RUF100` earns its place immediately.** Several noqa comments were written `# noqa F401` — no colon. Ruff reads that as a **blanket** suppression rather than a specific one, so those lines were silently suppressing *every* rule, not the one named. That's the same mechanism that hid the bare excepts. All are normalized; the stale ones (E722 references on clauses that aren't bare excepts) are dropped.

## Staying separable from #840

The bare `except:` clauses that E722 covers are **not** rewritten here — they keep their (now correctly scoped) `# noqa: E722`. Rewriting them is a behavior change and belongs with the fixes on the release branch, so this PR stays purely tooling and the two don't collide.

## The 109 findings

Most are mechanical — unused imports, f-strings with no placeholders, unsorted import blocks. The substantive ones:

- **`core/game.py`'s only Kivy import, `Clock`, was unused** — referenced solely in a comment. Removing it leaves `core/game.py` with no Kivy import at all, tightening the core/GUI separation the review singled out as a strength.
- **`__main__.py` resolved `PLAYER_AI` and `PlayerSetupBlock` only through a star import.** Both are now explicit. The star import stays, with a comment recording why it exists: it registers the kivyutils widget classes with Kivy's Factory so the `.kv` files can find them.
- **`popups.py` had a loop variable named `stat` shadowing the stdlib `stat` module** imported in the same file. I checked — harmless today, since the shadowing loop and the `stat.S_IXUSR` use are in different functions. Renamed anyway.
- **Two lambdas assigned to a name became `def`s**, which also removed a noqa the formatter had stranded mid-expression. Verified equivalent over the full board for every parameter combination rather than trusting the transcription.

## Verifying the GUI didn't break

Removing "unused" imports from a Kivy app is the risky part — an import can exist purely to register a class with the Factory so `.kv` files resolve it by name, and there is no GUI test coverage here.

I checked each candidate before removing it, then verified the result under Xvfb: the full import graph loads, both `.kv` files load, and **all 106 widget names referenced in the kv resolve through Kivy's Factory**. Identical before and after (one pre-existing false positive, `ToggleButtonMixin`, which derives from `ToggleButtonBehavior` rather than `Widget` and so is matched as a style rule instead of via Factory).

This is a static check, not a running app — it confirms name resolution, not that every screen renders.

## Cost

`ruff format` disagrees with black on 17 files, almost entirely spacing inside f-string expressions (`{n/1000:.1f}` → `{n / 1000:.1f}`) and slices. That's the one-time price of the switch.

## CI

⚠️ The CI step **could not be pushed** — changes under `.github/workflows/` need a token scope this session doesn't have. To enforce, add to the `test` job in `test_and_build.yaml` before "Run tests":

```yaml
    - name: Lint and format check
      run: |
        uv run ruff check .
        uv run ruff format --check .
```

## Testing

30 passed, 1 skipped (unchanged from `master`; the skip is `test_ai_strategies`, which launches a real KataGo and is already CI-skipped). `ruff check` and `ruff format --check` both clean. `i18n.py -todo` clean. `pyproject.toml` parses and no longer references black.