### PR TITLE
Bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -13,15 +13,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/checkout@v4
-    
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v7
       with:
         version: "0.7.8"
 

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -29,7 +29,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get project version
         id: version
@@ -44,7 +44,7 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python and uv
       uses: ./.github/actions/setup-python-uv
@@ -68,7 +68,7 @@ jobs:
       KATRAIN_VERSION: ${{ needs.prepare.outputs.version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python, uv
       uses: ./.github/actions/setup-python-uv
@@ -98,7 +98,7 @@ jobs:
       shell: powershell
 
     - name: Upload Windows artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: KaTrainWindows-${{ env.KATRAIN_VERSION }}
         path: windows_exe
@@ -120,12 +120,10 @@ jobs:
       KATRAIN_VERSION: ${{ needs.prepare.outputs.version }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python, uv, and PyInstaller
       uses: ./.github/actions/setup-python-uv
-      with:
-        install-pyinstaller: 'true'
 
     - name: Install macOS dependencies
       run: |
@@ -167,7 +165,7 @@ jobs:
         mv "KaTrain-${{ env.KATRAIN_VERSION }}-${{ matrix.arch }}.dmg" osx_app/
 
     - name: Upload macOS artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: KaTrainMacOS-${{ env.KATRAIN_VERSION }}-${{ matrix.arch }}
         path: osx_app
@@ -179,7 +177,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_pypi == 'true'
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Python and uv
       uses: ./.github/actions/setup-python-uv
@@ -205,14 +203,14 @@ jobs:
       contents: write # Required for softprops/action-gh-release
     steps:
     - name: Download all build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         path: ./artifacts
         pattern: KaTrain*
         merge-multiple: true
 
     - name: Create Draft Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: "v${{ needs.prepare.outputs.version }}"
         name: "KaTrain v${{ needs.prepare.outputs.version }}"


### PR DESCRIPTION
Clears the warnings on [run 32718382340](https://github.com/sanderland/katrain/actions/runs/32718382340).

- **Node 20 deprecation**: bumped to `checkout@v5`, `setup-python@v6`, `setup-uv@v7`, `upload-artifact@v5`, `download-artifact@v5`, `action-gh-release@v3` — all Node 24.
- **`Unexpected input(s) 'install-pyinstaller'`**: that input never existed on the `setup-python-uv` composite action. Removed; pyinstaller comes from the `dev` dependency group, which is in `default-groups`, so plain `uv sync` installs it.
- Dropped the redundant `actions/checkout` inside the composite action — every caller checks out first.

The remaining `aws/tap is not trusted` warnings come from the macOS runner image's preinstalled taps during `brew update`, not from this workflow.

Untested beyond the test/build jobs this PR runs; `action-gh-release@v3` only executes on a `workflow_dispatch` release, so that one is worth watching on the next dispatch. `setup-uv` still pins uv 0.7.8, left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)