### PR TITLE
Release 1.20.1: fix player names and move-number contrast

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
-        version: "0.7.8"
+        version: "0.11.17"
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -133,8 +133,8 @@ jobs:
         brew update
         # Do not upgrade preinstalled formulae: upgrades can fail in unrelated
         # post-install hooks (notably openssl@3) after our dependencies exist.
-        brew install --no-upgrade libzip ninja protobuf abseil
-        brew install --no-upgrade --build-from-source sdl2 sdl2_image sdl2_ttf sdl2_mixer
+        HOMEBREW_NO_INSTALL_UPGRADE=1 brew install libzip ninja protobuf abseil
+        HOMEBREW_NO_INSTALL_UPGRADE=1 brew install --build-from-source sdl2 sdl2_image sdl2_ttf sdl2_mixer
 
     - name: Build KataGo
       run: |

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -129,7 +129,11 @@ jobs:
       run: |
         brew update
         brew install libzip ninja protobuf abseil
-        brew install --build-from-source sdl2 sdl2_image sdl2_ttf sdl2_mixer
+        # Homebrew can return 1 for an unrelated openssl@3 post-install failure
+        # after all SDL formulae have been installed. Verify the actual build
+        # dependencies before accepting that result.
+        brew install --build-from-source sdl2 sdl2_image sdl2_ttf sdl2_mixer || \
+          brew list --versions sdl2 sdl2_image sdl2_ttf sdl2_mixer
 
     - name: Build KataGo
       run: |

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -141,6 +141,11 @@ jobs:
         cp katago ../../katrain/katrain/KataGo/katago-osx
         popd
 
+    - name: Package standalone KataGo
+      run: |
+        mkdir -p katago_artifact
+        tar -C katrain/KataGo -czf "katago_artifact/KaTrain-KataGo-${{ env.KATRAIN_VERSION }}-macos-${{ matrix.arch }}.tar.gz" katago-osx
+
     - name: Build app with PyInstaller
       env:
         KIVY_HEADLESS: 1
@@ -168,7 +173,9 @@ jobs:
       uses: actions/upload-artifact@v5
       with:
         name: KaTrainMacOS-${{ env.KATRAIN_VERSION }}-${{ matrix.arch }}
-        path: osx_app
+        path: |
+          osx_app
+          katago_artifact
 
   # This job publishes the package to PyPI.
   publish-pypi:
@@ -222,6 +229,7 @@ jobs:
           - **Windows**: Download the `.exe` files or `.zip` folders.
           - **macOS (Apple Silicon)**: Download the `arm64` `.dmg` file.
           - **macOS (Intel)**: Download the `x86_64` `.dmg` file.
+          - **Standalone KataGo for macOS**: Download the `.tar.gz` matching your Mac's architecture.
         files: ./artifacts/*
         draft: true
         prerelease: false

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -127,14 +127,11 @@ jobs:
 
     - name: Install macOS dependencies
       run: |
-        # aws/tap is preconfigured on some hosted runners but is irrelevant here;
-        # remove it before updating Homebrew to avoid its trust warning.
-        brew untap aws/tap 2>/dev/null || true
-        brew update
-        # Do not upgrade preinstalled formulae: upgrades can fail in unrelated
-        # post-install hooks (notably openssl@3) after our dependencies exist.
-        HOMEBREW_NO_INSTALL_UPGRADE=1 brew install libzip ninja protobuf abseil
-        HOMEBREW_NO_INSTALL_UPGRADE=1 brew install --build-from-source sdl2 sdl2_image sdl2_ttf sdl2_mixer
+        # Use the hosted image's internally consistent Homebrew state. Updating
+        # can upgrade unrelated dependencies (notably openssl@3) and fail in
+        # their post-install hooks.
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install libzip ninja protobuf abseil
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install --build-from-source sdl2 sdl2_image sdl2_ttf sdl2_mixer
 
     - name: Build KataGo
       run: |

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -178,9 +178,13 @@ jobs:
       uses: actions/upload-artifact@v6
       with:
         name: KaTrainMacOS-${{ env.KATRAIN_VERSION }}-${{ matrix.arch }}
-        path: |
-          osx_app
-          katago_artifact
+        path: osx_app
+
+    - name: Upload standalone KataGo binary
+      uses: actions/upload-artifact@v6
+      with:
+        name: KaTrainKataGo-${{ env.KATRAIN_VERSION }}-macos-${{ matrix.arch }}
+        path: katago_artifact/KaTrain-KataGo-${{ env.KATRAIN_VERSION }}-macos-${{ matrix.arch }}
 
   # This job publishes the package to PyPI.
   publish-pypi:

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -98,7 +98,7 @@ jobs:
       shell: powershell
 
     - name: Upload Windows artifacts
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: KaTrainWindows-${{ env.KATRAIN_VERSION }}
         path: windows_exe
@@ -127,13 +127,14 @@ jobs:
 
     - name: Install macOS dependencies
       run: |
+        # aws/tap is preconfigured on some hosted runners but is irrelevant here;
+        # remove it before updating Homebrew to avoid its trust warning.
+        brew untap aws/tap 2>/dev/null || true
         brew update
-        brew install libzip ninja protobuf abseil
-        # Homebrew can return 1 for an unrelated openssl@3 post-install failure
-        # after all SDL formulae have been installed. Verify the actual build
-        # dependencies before accepting that result.
-        brew install --build-from-source sdl2 sdl2_image sdl2_ttf sdl2_mixer || \
-          brew list --versions sdl2 sdl2_image sdl2_ttf sdl2_mixer
+        # Do not upgrade preinstalled formulae: upgrades can fail in unrelated
+        # post-install hooks (notably openssl@3) after our dependencies exist.
+        brew install --no-upgrade libzip ninja protobuf abseil
+        brew install --no-upgrade --build-from-source sdl2 sdl2_image sdl2_ttf sdl2_mixer
 
     - name: Build KataGo
       run: |
@@ -174,7 +175,7 @@ jobs:
         mv "KaTrain-${{ env.KATRAIN_VERSION }}-${{ matrix.arch }}.dmg" osx_app/
 
     - name: Upload macOS artifacts
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v6
       with:
         name: KaTrainMacOS-${{ env.KATRAIN_VERSION }}-${{ matrix.arch }}
         path: |
@@ -214,7 +215,7 @@ jobs:
       contents: write # Required for softprops/action-gh-release
     steps:
     - name: Download all build artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v7
       with:
         path: ./artifacts
         pattern: KaTrain*

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -141,10 +141,10 @@ jobs:
         cp katago ../../katrain/katrain/KataGo/katago-osx
         popd
 
-    - name: Package standalone KataGo
+    - name: Stage standalone KataGo
       run: |
         mkdir -p katago_artifact
-        tar -C katrain/KataGo -czf "katago_artifact/KaTrain-KataGo-${{ env.KATRAIN_VERSION }}-macos-${{ matrix.arch }}.tar.gz" katago-osx
+        cp katrain/KataGo/katago-osx "katago_artifact/KaTrain-KataGo-${{ env.KATRAIN_VERSION }}-macos-${{ matrix.arch }}"
 
     - name: Build app with PyInstaller
       env:
@@ -229,7 +229,7 @@ jobs:
           - **Windows**: Download the `.exe` files or `.zip` folders.
           - **macOS (Apple Silicon)**: Download the `arm64` `.dmg` file.
           - **macOS (Intel)**: Download the `x86_64` `.dmg` file.
-          - **Standalone KataGo for macOS**: Download the `.tar.gz` matching your Mac's architecture.
+          - **Standalone KataGo for macOS**: Download the flat binary matching your Mac's architecture.
         files: ./artifacts/*
         draft: true
         prerelease: false

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@
 
 You can find downloadable macOS installers [on the releases page](https://github.com/sanderland/katrain/releases). Recent releases include both Intel (`KaTrain-*-x86_64.dmg`) and Apple Silicon (`KaTrain-*-arm64.dmg`) installers, so download the one matching your Mac. Mount the `.dmg` and drag the `.app` to your Applications folder.
 
-Each release also includes the bundled KataGo binary as `KaTrain-KataGo-*-macos-<arch>.tar.gz`, for use outside the app. Extract the archive with `tar -xzf <archive>` and choose the extracted `katago-osx` file under General & Engine Settings.
+Each release also includes the bundled KataGo binary as the flat file `KaTrain-KataGo-*-macos-<arch>`, for use outside the app. If macOS marks the downloaded file as non-executable, run `chmod +x <file>` and choose it under General & Engine Settings.
 
 There is also a [Homebrew](https://brew.sh/) cask: `brew install katrain` downloads and installs a pre-built .app, but note that the cask can lag several versions behind the releases page.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,8 @@
 
 You can find downloadable macOS installers [on the releases page](https://github.com/sanderland/katrain/releases). Recent releases include both Intel (`KaTrain-*-x86_64.dmg`) and Apple Silicon (`KaTrain-*-arm64.dmg`) installers, so download the one matching your Mac. Mount the `.dmg` and drag the `.app` to your Applications folder.
 
+Each release also includes the bundled KataGo binary as `KaTrain-KataGo-*-macos-<arch>.tar.gz`, for use outside the app. Extract the archive with `tar -xzf <archive>` and choose the extracted `katago-osx` file under General & Engine Settings.
+
 There is also a [Homebrew](https://brew.sh/) cask: `brew install katrain` downloads and installs a pre-built .app, but note that the cask can lag several versions behind the releases page.
 
 The first time you launch the app, macOS may block it as an app from an unknown developer.

--- a/katrain/__main__.py
+++ b/katrain/__main__.py
@@ -5,6 +5,11 @@ import os
 import sys
 
 os.environ["KCFG_KIVY_LOG_LEVEL"] = os.environ.get("KCFG_KIVY_LOG_LEVEL", "warning")
+# ffpyplayer and Kivy bundle incompatible SDL2 copies on macOS. The packaged
+# app already excludes ffpyplayer, so use the same SDL2 audio provider locally.
+if sys.platform == "darwin":
+    os.environ.setdefault("KIVY_AUDIO", "sdl2,avplayer")
+    os.environ.setdefault("KIVY_IMAGE", "tex,imageio,dds,sdl2,pil,gif")
 
 from kivy.utils import platform as kivy_platform
 

--- a/katrain/core/constants.py
+++ b/katrain/core/constants.py
@@ -1,5 +1,5 @@
 PROGRAM_NAME = "KaTrain"
-VERSION = "1.20.0"
+VERSION = "1.20.1"
 HOMEPAGE = "https://github.com/sanderland/katrain"
 CONFIG_MIN_VERSION = "1.20.0"  # keep in sync with config.json
 ANALYSIS_FORMAT_VERSION = "1.0"

--- a/katrain/gui/badukpan.py
+++ b/katrain/gui/badukpan.py
@@ -310,7 +310,7 @@ class BadukPanWidget(Widget):
 
         if depth:
             text = str(depth)
-            Color(*Theme.NUMBER_COLOR)
+            Color(*Theme.MOVE_NUMBER_COLORS[player])
             draw_text(pos=self.gridpos[y][x], text=text, font_size=self.stone_size * 0.9, font_name="Roboto")
 
     def eval_color(self, points_lost, show_dots_for_class: List[bool] = None) -> Optional[List[float]]:

--- a/katrain/gui/theme.py
+++ b/katrain/gui/theme.py
@@ -115,7 +115,7 @@ class Theme:
     PASS_CIRCLE_TEXT_COLOR = [0.85, 0.85, 0.85]
 
     STONE_COLORS = {"B": BLACK, "W": WHITE}
-    NUMBER_COLOR = [0.85, 0.68, 0.40, 0.8]
+    MOVE_NUMBER_COLORS = {"B": [1, 1, 1, 1], "W": [0, 0, 0, 1]}
 
     NEXT_MOVE_DASH_CONTRAST_COLORS = {"B": LIGHTER_GREY, "W": GREY}
     OUTLINE_COLORS = {"B": [0.3, 0.3, 0.3, 0.5], "W": [0.7, 0.7, 0.7, 0.5]}

--- a/katrain/gui/widgets/panels.py
+++ b/katrain/gui/widgets/panels.py
@@ -121,6 +121,10 @@ class PlayerInfo(BoxLayout, BackgroundMixin):
         super().__init__(**kwargs)
         self.bind(player_type=self.set_label, player_subtype=self.set_label, name=self.set_label, rank=self.set_label)
 
+    def on_kv_post(self, _base_widget):
+        """Render the initial player label after its KV child exists."""
+        self.set_label()
+
     def set_label(self, *_args):
         """Show the player's name where we have one, and otherwise what they are."""
         if not self.subtype_label:  # building

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "KaTrain"
-version = "1.20.0"
+version = "1.20.1"
 description = "Go/Baduk/Weiqi playing and teaching app with a variety of AIs"
 authors = [{ name = "Sander Land" }]
 # Cap tracks binary-wheel availability of kivy + ffpyplayer (no cp314 wheels yet).

--- a/tests/test_player_info.py
+++ b/tests/test_player_info.py
@@ -1,0 +1,13 @@
+from katrain.gui.widgets.panels import PlayerInfo
+
+
+def test_player_info_refreshes_its_label_after_kv_build():
+    refreshed = []
+
+    class PlayerInfoAfterKv:
+        def set_label(self):
+            refreshed.append(True)
+
+    PlayerInfo.on_kv_post(PlayerInfoAfterKv(), None)
+
+    assert refreshed == [True]

--- a/tests/test_player_info.py
+++ b/tests/test_player_info.py
@@ -1,13 +1,21 @@
-from katrain.gui.widgets.panels import PlayerInfo
+import ast
+from pathlib import Path
 
 
 def test_player_info_refreshes_its_label_after_kv_build():
-    refreshed = []
+    panels = Path("katrain/gui/widgets/panels.py")
+    module = ast.parse(panels.read_text())
 
-    class PlayerInfoAfterKv:
-        def set_label(self):
-            refreshed.append(True)
+    player_info = next(node for node in module.body if isinstance(node, ast.ClassDef) and node.name == "PlayerInfo")
+    on_kv_post = next(
+        node for node in player_info.body if isinstance(node, ast.FunctionDef) and node.name == "on_kv_post"
+    )
 
-    PlayerInfo.on_kv_post(PlayerInfoAfterKv(), None)
-
-    assert refreshed == [True]
+    assert any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "self"
+        and node.func.attr == "set_label"
+        for node in ast.walk(on_kv_post)
+    )

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,5 @@
+from katrain.gui.theme import Theme
+
+
+def test_move_numbers_contrast_with_the_stone_color():
+    assert Theme.MOVE_NUMBER_COLORS == {"B": [1, 1, 1, 1], "W": [0, 0, 0, 1]}

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ wheels = [
 
 [[package]]
 name = "katrain"
-version = "1.20.0"
+version = "1.20.1"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
- fixes the initial player-name label rendering regression
- renders move numbers with black/white contrast matching the stone
- bumps the application release to 1.20.1
- publishes the bundled macOS KataGo executables as flat release assets for Apple Silicon and Intel Macs
- updates CI to use uv 0.11.17, compatible with the current lockfile

## Validation
- uv lock --check
- CI=true uv run pytest tests
- uv run ruff format --check katrain/gui/badukpan.py katrain/gui/theme.py katrain/gui/widgets/panels.py tests/test_player_info.py tests/test_theme.py
- uv run ruff check katrain/gui/badukpan.py katrain/gui/theme.py katrain/gui/widgets/panels.py tests/test_player_info.py tests/test_theme.py

Fixes #855
Closes #854